### PR TITLE
Feature: withdraw proposal

### DIFF
--- a/server/migrations/2026-04-12-200044-0000_withdraw_proposal/down.sql
+++ b/server/migrations/2026-04-12-200044-0000_withdraw_proposal/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE IF EXISTS withdraw_proposal;

--- a/server/migrations/2026-04-12-200044-0000_withdraw_proposal/up.sql
+++ b/server/migrations/2026-04-12-200044-0000_withdraw_proposal/up.sql
@@ -1,0 +1,17 @@
+-- Your SQL goes here
+
+-- =========================
+-- WITHDRAW PROPOSAL
+-- =========================
+
+CREATE TABLE withdraw_proposal (
+	proposal_id UUID PRIMARY KEY,
+
+	amount NUMERIC NOT NULL CHECK (amount > 0),
+
+	created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+	updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+
+	FOREIGN KEY (proposal_id) REFERENCES "proposal"(id) ON DELETE CASCADE
+);
+

--- a/server/migrations/2026-04-12-200044-0000_withdraw_proposal/up.sql
+++ b/server/migrations/2026-04-12-200044-0000_withdraw_proposal/up.sql
@@ -9,9 +9,6 @@ CREATE TABLE withdraw_proposal (
 
 	amount NUMERIC NOT NULL CHECK (amount > 0),
 
-	created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-	updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
-
 	FOREIGN KEY (proposal_id) REFERENCES "proposal"(id) ON DELETE CASCADE
 );
 

--- a/server/src/models/proposal.rs
+++ b/server/src/models/proposal.rs
@@ -29,6 +29,7 @@ pub enum MyVoteType {
 pub enum ProposalType {
     NewMember,
     FundRound,
+    Withdraw,
 }
 
 #[derive(Queryable, Serialize, Selectable)]

--- a/server/src/models/proposals/mod.rs
+++ b/server/src/models/proposals/mod.rs
@@ -1,2 +1,3 @@
 pub mod fund_round;
 pub mod new_member;
+pub mod withdraw;

--- a/server/src/models/proposals/withdraw.rs
+++ b/server/src/models/proposals/withdraw.rs
@@ -1,7 +1,6 @@
 use crate::models::proposal::{Proposal, ProposalType};
 use crate::schema::withdraw_proposal;
 use bigdecimal::BigDecimal;
-use chrono::NaiveDateTime;
 use diesel::{Insertable, Queryable, Selectable};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;

--- a/server/src/models/proposals/withdraw.rs
+++ b/server/src/models/proposals/withdraw.rs
@@ -1,0 +1,42 @@
+use crate::models::proposal::{Proposal, ProposalType};
+use crate::schema::withdraw_proposal;
+use bigdecimal::BigDecimal;
+use chrono::NaiveDateTime;
+use diesel::{Insertable, Queryable, Selectable};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Queryable, Serialize, Deserialize, Selectable)]
+#[diesel(table_name = withdraw_proposal)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct WithdrawProposal {
+    pub proposal_id: Uuid,
+    pub amount: BigDecimal,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+}
+
+#[derive(Insertable, Serialize, Deserialize)]
+#[diesel(table_name = withdraw_proposal)]
+pub struct NewWithdrawProposal {
+    pub proposal_id: Uuid,
+    pub amount: BigDecimal,
+}
+
+#[derive(Serialize)]
+#[allow(dead_code)] // TODO: remove after implemented
+pub struct WithdrawProposalExpanded {
+    pub proposal: Proposal,
+    pub withdraw_proposal: WithdrawProposal,
+    pub proposal_type: ProposalType,
+}
+
+#[derive(Serialize)]
+#[allow(dead_code)] // TODO: remove after implemented
+pub struct ReceivedWithdrawProposalExpanded {
+    pub sender_name: String,
+    pub group_name: String,
+    pub proposal: Proposal,
+    pub withdraw_proposal: WithdrawProposal,
+    pub proposal_type: ProposalType,
+}

--- a/server/src/models/proposals/withdraw.rs
+++ b/server/src/models/proposals/withdraw.rs
@@ -5,17 +5,10 @@ use diesel::{Insertable, Queryable, Selectable};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Queryable, Serialize, Deserialize, Selectable)]
+#[derive(Queryable, Insertable, Serialize, Deserialize, Selectable)]
 #[diesel(table_name = withdraw_proposal)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct WithdrawProposal {
-    pub proposal_id: Uuid,
-    pub amount: BigDecimal,
-}
-
-#[derive(Insertable, Serialize, Deserialize)]
-#[diesel(table_name = withdraw_proposal)]
-pub struct NewWithdrawProposal {
     pub proposal_id: Uuid,
     pub amount: BigDecimal,
 }

--- a/server/src/models/proposals/withdraw.rs
+++ b/server/src/models/proposals/withdraw.rs
@@ -12,8 +12,6 @@ use uuid::Uuid;
 pub struct WithdrawProposal {
     pub proposal_id: Uuid,
     pub amount: BigDecimal,
-    pub created_at: NaiveDateTime,
-    pub updated_at: NaiveDateTime,
 }
 
 #[derive(Insertable, Serialize, Deserialize)]

--- a/server/src/schema.rs
+++ b/server/src/schema.rs
@@ -180,8 +180,6 @@ diesel::table! {
     withdraw_proposal (proposal_id) {
         proposal_id -> Uuid,
         amount -> Numeric,
-        created_at -> Timestamp,
-        updated_at -> Timestamp,
     }
 }
 

--- a/server/src/schema.rs
+++ b/server/src/schema.rs
@@ -176,6 +176,15 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    withdraw_proposal (proposal_id) {
+        proposal_id -> Uuid,
+        amount -> Numeric,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
 diesel::joinable!(fund_round_contribution -> fund_round_proposal (fund_round_proposal_id));
 diesel::joinable!(fund_round_contribution -> transaction (transaction_id));
 diesel::joinable!(fund_round_contribution -> user (user_id));
@@ -198,6 +207,7 @@ diesel::joinable!(user_wallet -> currency (currency_id));
 diesel::joinable!(user_wallet -> user (user_id));
 diesel::joinable!(vote -> proposal (proposal_id));
 diesel::joinable!(vote -> user (user_id));
+diesel::joinable!(withdraw_proposal -> proposal (proposal_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
     currency,
@@ -213,4 +223,5 @@ diesel::allow_tables_to_appear_in_same_query!(
     user_in_group,
     user_wallet,
     vote,
+    withdraw_proposal,
 );


### PR DESCRIPTION
This pull request adds support for "withdraw" proposals to the system. It introduces a new `withdraw_proposal` table, updates the schema and models accordingly, and integrates the new proposal type into the codebase. The main changes are grouped below:

**Database schema changes:**

* Created a new `withdraw_proposal` table with `proposal_id` as a primary key, a positive `amount` field, and a foreign key reference to the `proposal` table. [[1]](diffhunk://#diff-205755a416a5a914b8f4bf310f743b8157b2e751519ba675322f82ae837abd40R1-R14) [[2]](diffhunk://#diff-8d20d075ab6ef3ba2c89ab6d06abc00c601662545b1a9e0b6ea855e970e31391R179-R185)
* Added migration scripts to create and drop the `withdraw_proposal` table. [[1]](diffhunk://#diff-205755a416a5a914b8f4bf310f743b8157b2e751519ba675322f82ae837abd40R1-R14) [[2]](diffhunk://#diff-c3ac2e19efbd80a2c9c2719fae9bffa3bab797f8247db3c0e0be8b7632f91d96R1-R2)
* Updated schema relationships and allowed `withdraw_proposal` to appear in queries with other tables. [[1]](diffhunk://#diff-8d20d075ab6ef3ba2c89ab6d06abc00c601662545b1a9e0b6ea855e970e31391R208) [[2]](diffhunk://#diff-8d20d075ab6ef3ba2c89ab6d06abc00c601662545b1a9e0b6ea855e970e31391R224)

**Model and code updates:**

* Added a new `Withdraw` variant to the `ProposalType` enum in `proposal.rs`.
* Created a new module `withdraw` under `server/src/models/proposals/` and defined related structs for modeling withdraw proposals. [[1]](diffhunk://#diff-0d0131e093a412b38e37f88732dff2757a3771bde6b7296a4c6fd9a7fc946991R3) [[2]](diffhunk://#diff-8149348813c312a6837a24e50e4061a14eb58c76288c6cbb129a4e7183c77813R1-R39)