### PR TITLE
Feature: boton para proponer una withdrawalproposal

### DIFF
--- a/client/src/lib/api/endpoints/proposals.ts
+++ b/client/src/lib/api/endpoints/proposals.ts
@@ -6,6 +6,7 @@ import type {
 	NewMemberData,
 	ReceivedNewMemberProposalExpanded
 } from '$lib/types/endpoints/proposals.types';
+import type { WithdrawProposalExpanded } from '$lib/types/endpoints/transactions.types';
 
 export async function createNewMemberProposal(data: NewMemberData): ApiResponse<ExpandedProposal> {
 	return authedApiFetch(`/proposal/new-member/${data.group_id}`, {

--- a/client/src/lib/api/endpoints/proposals.ts
+++ b/client/src/lib/api/endpoints/proposals.ts
@@ -6,7 +6,6 @@ import type {
 	NewMemberData,
 	ReceivedNewMemberProposalExpanded
 } from '$lib/types/endpoints/proposals.types';
-import type { WithdrawProposalExpanded } from '$lib/types/endpoints/transactions.types';
 
 export async function createNewMemberProposal(data: NewMemberData): ApiResponse<ExpandedProposal> {
 	return authedApiFetch(`/proposal/new-member/${data.group_id}`, {

--- a/client/src/lib/api/endpoints/transactions.ts
+++ b/client/src/lib/api/endpoints/transactions.ts
@@ -2,6 +2,8 @@ import { authedApiFetch } from '../client';
 
 import type { ApiResponse } from '$lib/types/client.types';
 import type {
+	ExecuteWithdrawProposal,
+	Transaction,
 	WithdrawProposalExpanded,
 	WithdrawProposalRequest
 } from '$lib/types/endpoints/transactions.types';
@@ -17,5 +19,23 @@ export async function proposeWithdraw(
 			address: request.user_address,
 			amount: request.amount
 		})
+	});
+}
+
+export async function getAllWithdrawProposals(
+	group_id: string
+): ApiResponse<WithdrawProposalExpanded[]> {
+	return authedApiFetch(`/proposal/withdraw/${group_id}`, {
+		method: 'GET'
+	});
+}
+
+export async function executeWithdrawProposal(
+	group_id: string,
+	execute: ExecuteWithdrawProposal
+): ApiResponse<Transaction> {
+	return authedApiFetch(`/transaction/${group_id}/withdraw/execute`, {
+		method: 'POST',
+		body: JSON.stringify(execute)
 	});
 }

--- a/client/src/lib/api/endpoints/transactions.ts
+++ b/client/src/lib/api/endpoints/transactions.ts
@@ -1,0 +1,21 @@
+import { authedApiFetch } from '../client';
+
+import type { ApiResponse } from '$lib/types/client.types';
+import type {
+	WithdrawProposalExpanded,
+	WithdrawProposalRequest
+} from '$lib/types/endpoints/transactions.types';
+
+export async function proposeWithdraw(
+	request: WithdrawProposalRequest,
+	group_id: string
+): ApiResponse<WithdrawProposalExpanded> {
+	return authedApiFetch(`/transaction/${group_id}/withdraw/proposal`, {
+		method: 'POST',
+		body: JSON.stringify({
+			currency_id: request.currency_id,
+			address: request.user_address,
+			amount: request.amount
+		})
+	});
+}

--- a/client/src/lib/components/WithdrawProposalDrawer.svelte
+++ b/client/src/lib/components/WithdrawProposalDrawer.svelte
@@ -1,0 +1,275 @@
+<script lang="ts">
+	import { X, HandCoins, CheckCircle2, Clock, ChevronRight, Loader2 } from 'lucide-svelte';
+	import { fade, slide } from 'svelte/transition';
+	import { authStore } from '$lib/stores/auth'; // Ajustá la ruta a tu store
+
+	import Button from '$lib/components/ui/Button.svelte';
+	import {
+		getAllWithdrawProposals,
+		executeWithdrawProposal
+	} from '$lib/api/endpoints/transactions';
+	import { getMyWallets } from '$lib/api/endpoints/wallets';
+	import { isSuccess } from '$lib/types/client.types';
+
+	import type { WithdrawProposalExpanded } from '$lib/types/endpoints/transactions.types';
+	import type { WalletCurrency } from '$lib/types/endpoints/wallets.types';
+	import { shortenAddress } from '$lib/utils/address_utils';
+
+	interface Props {
+		open: boolean;
+		group_id: string;
+		onclose: () => void;
+		onsuccess?: () => void;
+	}
+
+	const { open, group_id, onclose, onsuccess }: Props = $props();
+
+	// Estados
+	let loading = $state(true);
+	let actionLoading = $state(false);
+	let proposals = $state<WithdrawProposalExpanded[]>([]);
+	let wallets = $state<WalletCurrency[]>([]);
+	let error = $state('');
+
+	// Estado para el acordeón de ejecución
+	let executingProposalId = $state<string | null>(null);
+	let selectedWalletId = $state<string>('');
+
+	// Derivados
+	const currentUserId = $derived($authStore.user?.id);
+	const selectedWallet = $derived(wallets.find((w) => w.wallet_id === selectedWalletId));
+
+	// Funciones de carga
+	async function loadData() {
+		loading = true;
+		error = '';
+
+		// Cargamos propuestas y wallets en paralelo para que sea más rápido
+		const [proposalsRes, walletsRes] = await Promise.all([
+			getAllWithdrawProposals(group_id),
+			getMyWallets()
+		]);
+
+		if (isSuccess(proposalsRes)) {
+			proposals = proposalsRes.body;
+		} else {
+			error = 'No se pudieron cargar las propuestas.';
+		}
+
+		if (isSuccess(walletsRes)) {
+			wallets = walletsRes.body.flatMap((group) => group.currencies);
+		}
+
+		loading = false;
+	}
+
+	$effect(() => {
+		if (open) {
+			loadData();
+			// Reseteamos el estado visual al abrir
+			executingProposalId = null;
+			selectedWalletId = '';
+		}
+	});
+
+	// Lógica del acordeón
+	function toggleExecution(proposalId: string) {
+		if (executingProposalId === proposalId) {
+			executingProposalId = null;
+			selectedWalletId = '';
+		} else {
+			executingProposalId = proposalId;
+			selectedWalletId = '';
+		}
+	}
+
+	// Ejecutar
+	async function handleExecute(proposal: WithdrawProposalExpanded) {
+		if (!selectedWallet) return;
+
+		actionLoading = true;
+		error = '';
+
+		const request = {
+			currency_id: proposal.withdraw_proposal.currency_id,
+			proposal_id: proposal.proposal.id,
+			address: selectedWallet.address
+		};
+
+		const res = await executeWithdrawProposal(group_id, request);
+
+		actionLoading = false;
+
+		if (!isSuccess(res)) {
+			error = res.message || 'Error al ejecutar la propuesta.';
+			return;
+		}
+
+		// Si fue un éxito, cerramos el acordeón y recargamos la lista
+		executingProposalId = null;
+		selectedWalletId = '';
+		await loadData();
+		onsuccess?.();
+	}
+</script>
+
+{#if open}
+	<div
+		role="presentation"
+		tabindex="-1"
+		class="fixed inset-0 z-40 bg-black/20 backdrop-blur-sm transition-opacity"
+		transition:fade={{ duration: 200 }}
+		onclick={onclose}
+		onkeydown={(e) => e.key === 'Escape' && onclose()}
+	></div>
+
+	<div
+		class="fixed inset-y-0 right-0 z-50 flex w-full max-w-md flex-col border-l border-gray-200 bg-white shadow-2xl"
+		transition:slide={{ axis: 'x', duration: 300 }}
+	>
+		<div class="flex items-center justify-between border-b border-gray-200 px-6 py-4">
+			<h2 class="text-lg font-bold text-black">Propuestas de Retiro</h2>
+			<button
+				onclick={onclose}
+				class="rounded-md p-1.5 text-gray-400 transition hover:bg-gray-100 hover:text-black"
+			>
+				<X class="h-5 w-5" />
+			</button>
+		</div>
+
+		<div class="flex-1 overflow-y-auto p-6">
+			{#if error}
+				<div class="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-600">
+					{error}
+				</div>
+			{/if}
+
+			{#if loading}
+				<div class="flex items-center justify-center py-10">
+					<Loader2 class="h-6 w-6 animate-spin text-gray-400" />
+				</div>
+			{:else if proposals.length === 0}
+				<div class="flex flex-col items-center justify-center py-12 text-center">
+					<HandCoins class="mb-3 h-8 w-8 text-gray-300" />
+					<p class="text-sm font-medium text-black">Sin propuestas</p>
+					<p class="text-sm text-gray-500">No hay retiros pendientes en este grupo.</p>
+				</div>
+			{:else}
+				<div class="space-y-4">
+					{#each proposals as p}
+						{@const isOwner = p.proposal.created_by === currentUserId}
+						{@const isApproved = p.proposal.status === 'Approved'}
+						{@const isExecuted = p.proposal.status === 'Executed'}
+						{@const compatibleWallets = wallets.filter(
+							(w) => w.currency_id === p.withdraw_proposal.currency_id
+						)}
+
+						<div
+							class="overflow-hidden rounded-lg border border-gray-200 bg-white transition-all hover:border-gray-300"
+						>
+							<div class="p-4">
+								<div class="flex items-start justify-between">
+									<div class="space-y-1">
+										<div class="flex items-center gap-2">
+											<span class="text-lg font-bold text-black">${p.withdraw_proposal.amount}</span
+											>
+										</div>
+										<div class="text-xs text-gray-500 capitalize">
+											{new Date(p.proposal.created_at).toLocaleDateString('es-AR', {
+												day: '2-digit',
+												month: 'short',
+												year: 'numeric'
+											})}
+										</div>
+									</div>
+
+									{#if isExecuted}
+										<span
+											class="inline-flex items-center gap-1 rounded bg-black px-2 py-1 text-xs font-medium text-white"
+										>
+											<CheckCircle2 class="h-3 w-3" /> Ejecutado
+										</span>
+									{:else if isApproved}
+										<span
+											class="inline-flex items-center gap-1 rounded border border-green-200 bg-green-50 px-2 py-1 text-xs font-medium text-green-700"
+										>
+											Aprobado
+										</span>
+									{:else}
+										<span
+											class="inline-flex items-center gap-1 rounded border border-gray-200 bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600"
+										>
+											<Clock class="h-3 w-3" /> Pendiente
+										</span>
+									{/if}
+								</div>
+
+								{#if isOwner && isApproved && !isExecuted}
+									<div class="mt-4 border-t border-gray-100 pt-3">
+										<button
+											onclick={() => toggleExecution(p.proposal.id)}
+											class="flex w-full items-center justify-between text-sm font-medium transition-colors {executingProposalId ===
+											p.proposal.id
+												? 'text-black'
+												: 'text-gray-500 hover:text-black'}"
+										>
+											<span>Ejecutar retiro</span>
+											<ChevronRight
+												class="h-4 w-4 transition-transform {executingProposalId === p.proposal.id
+													? 'rotate-90'
+													: ''}"
+											/>
+										</button>
+									</div>
+								{/if}
+							</div>
+
+							{#if executingProposalId === p.proposal.id}
+								<div
+									class="border-t border-gray-100 bg-gray-50 p-4"
+									transition:slide={{ duration: 200 }}
+								>
+									<label
+										for="wallet-select-{p.proposal.id}"
+										class="mb-2 block text-xs font-medium text-gray-600"
+									>
+										Seleccioná tu wallet de destino
+									</label>
+
+									{#if compatibleWallets.length === 0}
+										<p class="text-xs text-red-500">
+											No tenés wallets compatibles con esta moneda.
+										</p>
+									{:else}
+										<select
+											id="wallet-select-{p.proposal.id}"
+											bind:value={selectedWalletId}
+											class="mb-3 w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-sm text-black focus:border-black focus:ring-0 focus:outline-none"
+										>
+											<option value="" disabled>Elegí una wallet</option>
+											{#each compatibleWallets as w}
+												<option value={w.wallet_id}>
+													{shortenAddress(w.address) + ' - ' + w.ticker}
+												</option>
+											{/each}
+										</select>
+
+										<div class="flex justify-end">
+											<Button
+												label="Confirmar Ejecución"
+												variant="primary"
+												disabled={!selectedWalletId || actionLoading}
+												loading={actionLoading}
+												onclick={() => handleExecute(p)}
+											/>
+										</div>
+									{/if}
+								</div>
+							{/if}
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</div>
+	</div>
+{/if}

--- a/client/src/lib/components/WithdrawProposalDrawer.svelte
+++ b/client/src/lib/components/WithdrawProposalDrawer.svelte
@@ -111,8 +111,14 @@
 		await loadData();
 		onsuccess?.();
 	}
+	function handleWindowKeydown(e: KeyboardEvent) {
+		if (open && e.key === 'Escape') {
+			onclose();
+		}
+	}
 </script>
 
+<svelte:window onkeydown={handleWindowKeydown} />
 {#if open}
 	<div
 		role="presentation"
@@ -120,7 +126,6 @@
 		class="fixed inset-0 z-40 bg-black/20 backdrop-blur-sm transition-opacity"
 		transition:fade={{ duration: 200 }}
 		onclick={onclose}
-		onkeydown={(e) => e.key === 'Escape' && onclose()}
 	></div>
 
 	<div

--- a/client/src/lib/components/WithdrawProposalDrawer.svelte
+++ b/client/src/lib/components/WithdrawProposalDrawer.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { X, HandCoins, CheckCircle2, Clock, ChevronRight, Loader2 } from 'lucide-svelte';
 	import { fade, slide } from 'svelte/transition';
-	import { authStore } from '$lib/stores/auth'; // Ajustá la ruta a tu store
+	import { authStore } from '$lib/stores/auth';
 
 	import Button from '$lib/components/ui/Button.svelte';
 	import {

--- a/client/src/lib/components/modals/ProposeWithdrawModal.svelte
+++ b/client/src/lib/components/modals/ProposeWithdrawModal.svelte
@@ -1,0 +1,188 @@
+<script lang="ts">
+	import Modal from '$lib/components/modals/Modal.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import FormField from '$lib/components/ui/FormField.svelte';
+	import { X } from 'lucide-svelte';
+
+	import { proposeWithdraw } from '$lib/api/endpoints/transactions';
+	import { getMyWallets } from '$lib/api/endpoints/wallets';
+	import { isSuccess } from '$lib/types/client.types';
+	import type { WalletCurrency } from '$lib/types/endpoints/wallets.types';
+
+	interface Props {
+		open: boolean;
+		group_id: string;
+		currency_id: string;
+		onclose: () => void;
+		onsuccess?: () => void;
+	}
+
+	const { open, group_id, currency_id, onclose, onsuccess }: Props = $props();
+
+	let wallets = $state<WalletCurrency[]>([]);
+	let loadingWallets = $state(false);
+	let selectedWalletId = $state('');
+	let amount = $state('');
+	let attempted = $state(false);
+	let error = $state('');
+	let success = $state('');
+	let loading = $state(false);
+
+	const selectedWallet = $derived(wallets.find((w) => w.wallet_id === selectedWalletId));
+
+	const amountValid = $derived(
+		amount != null &&
+			amount !== '' &&
+			!isNaN(Number(String(amount).replace(',', '.'))) &&
+			Number(String(amount).replace(',', '.')) > 0
+	);
+
+	const walletSelected = $derived(selectedWalletId !== '');
+	const formValid = $derived(walletSelected && amountValid);
+
+	async function loadWallets() {
+		loadingWallets = true;
+		const res = await getMyWallets();
+		loadingWallets = false;
+		if (!isSuccess(res)) {
+			error = 'No se pudieron cargar tus wallets.';
+			return;
+		}
+		wallets = res.body
+			.flatMap((group) => group.currencies)
+			.filter((w) => w.currency_id === currency_id);
+	}
+
+	$effect(() => {
+		if (open) {
+			loadWallets();
+		}
+	});
+
+	async function handleSubmit(e: SubmitEvent) {
+		e.preventDefault();
+		attempted = true;
+
+		if (!formValid || !selectedWallet) return;
+
+		error = '';
+		success = '';
+		loading = true;
+
+		const request = {
+			currency_id,
+			user_address: selectedWallet.address,
+			amount: String(amount).replace(',', '.')
+		};
+
+		const response = await proposeWithdraw(request, group_id);
+
+		loading = false;
+
+		if (!isSuccess(response)) {
+			error = response.message || 'Error al proponer el retiro.';
+			return;
+		}
+
+		success = 'Propuesta de retiro creada exitosamente!';
+
+		setTimeout(() => {
+			handleClose();
+			onsuccess?.();
+		}, 1200);
+	}
+
+	function handleClose() {
+		selectedWalletId = '';
+		amount = '';
+		attempted = false;
+		error = '';
+		success = '';
+		loading = false;
+		wallets = [];
+		onclose();
+	}
+</script>
+
+<Modal
+	{open}
+	title="Proponer Retiro"
+	description="Creá una propuesta para retirar fondos de la wallet del grupo hacia tu cuenta personal."
+	onclose={handleClose}
+	{error}
+	{success}
+	{loading}
+>
+	{#snippet children()}
+		<form id="propose-withdraw-form" onsubmit={handleSubmit} class="space-y-4">
+			<FormField
+				id="withdraw-amount"
+				label="Monto a retirar"
+				minLength={0}
+				maxLength={3}
+				type="number"
+				placeholder="0.00"
+				bind:value={amount}
+				{attempted}
+			/>
+
+			<div>
+				<label for="destination-wallet" class="mb-1.5 block text-sm font-medium text-black">
+					Wallet de destino (Tu cuenta)
+				</label>
+
+				{#if loadingWallets}
+					<div class="flex items-center gap-2 py-2">
+						<div
+							class="h-4 w-4 animate-spin rounded-full border-2 border-gray-200 border-t-black"
+						></div>
+						<span class="text-sm text-gray-400">Buscando wallets compatibles...</span>
+					</div>
+				{:else if wallets.length === 0}
+					<p class="rounded-md border border-gray-200 bg-gray-50 p-3 text-sm text-gray-500">
+						No tenés wallets compatibles con la moneda de este grupo.
+					</p>
+				{:else}
+					<select
+						id="destination-wallet"
+						bind:value={selectedWalletId}
+						class="w-full rounded-md border px-3 py-2 text-sm text-black transition focus:ring-0 focus:outline-none
+                      {attempted && !walletSelected
+							? 'border-red-400 focus:border-red-500'
+							: selectedWalletId
+								? 'border-green-400 focus:border-green-500'
+								: 'border-gray-200 focus:border-gray-400'}"
+					>
+						<option value="" disabled>Elegí una wallet de destino</option>
+						{#each wallets as wallet}
+							<option value={wallet.wallet_id}>
+								{wallet.address.length > 10
+									? wallet.address.slice(0, 8) + '...' + wallet.address.slice(-6)
+									: wallet.address} — {wallet.ticker}
+							</option>
+						{/each}
+					</select>
+
+					{#if attempted && !walletSelected}
+						<p class="mt-1.5 flex items-center gap-1 text-xs text-red-500">
+							<X class="h-3.5 w-3.5 shrink-0" />
+							Seleccioná una wallet de destino
+						</p>
+					{/if}
+				{/if}
+			</div>
+		</form>
+	{/snippet}
+
+	{#snippet footer()}
+		<Button label="Cancelar" variant="secondary" onclick={handleClose} />
+
+		<Button
+			label="Proponer"
+			type="submit"
+			form="propose-withdraw-form"
+			disabled={!formValid}
+			{loading}
+		/>
+	{/snippet}
+</Modal>

--- a/client/src/lib/types/endpoints/transactions.types.ts
+++ b/client/src/lib/types/endpoints/transactions.types.ts
@@ -21,7 +21,7 @@ export type ExecuteWithdrawProposal = {
 export type WithdrawProposalExpanded = {
 	proposal: Proposal;
 	withdraw_proposal: WithdrawProposal;
-	proposal_type: string;
+	proposal_type: 'Withdraw';
 };
 
 export type Transaction = {

--- a/client/src/lib/types/endpoints/transactions.types.ts
+++ b/client/src/lib/types/endpoints/transactions.types.ts
@@ -1,0 +1,19 @@
+import type { Proposal } from '$lib/types/endpoints/proposals.types';
+
+export type WithdrawProposal = {
+	proposal_id: string;
+	amount: string;
+	currency_id: string;
+};
+
+export type WithdrawProposalRequest = {
+	currency_id: string;
+	user_address: string;
+	amount: string;
+};
+
+export type WithdrawProposalExpanded = {
+	proposal: Proposal;
+	withdraw_proposal: WithdrawProposal;
+	proposal_type: string;
+};

--- a/client/src/lib/types/endpoints/transactions.types.ts
+++ b/client/src/lib/types/endpoints/transactions.types.ts
@@ -12,8 +12,28 @@ export type WithdrawProposalRequest = {
 	amount: string;
 };
 
+export type ExecuteWithdrawProposal = {
+	currency_id: string;
+	proposal_id: string;
+	address: string;
+};
+
 export type WithdrawProposalExpanded = {
 	proposal: Proposal;
 	withdraw_proposal: WithdrawProposal;
 	proposal_type: string;
+};
+
+export type Transaction = {
+	id: string;
+	tx_hash: string | null;
+	amount: string;
+	user_id: string;
+	group_id: string;
+	currency_id: string;
+	address: string;
+	description: string | null;
+	tx_type: string;
+	created_at: string;
+	updated_at: string;
 };

--- a/client/src/lib/types/endpoints/wallets.types.ts
+++ b/client/src/lib/types/endpoints/wallets.types.ts
@@ -1,6 +1,7 @@
 export type WalletCurrency = {
 	wallet_id: string;
 	address: string;
+	currency_id: string;
 	balance: string;
 	ticker: string;
 };

--- a/client/src/routes/groups/[group_id]/+page.svelte
+++ b/client/src/routes/groups/[group_id]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Trash2, Pencil, Wallet, Coins, Plus, Copy } from 'lucide-svelte';
+	import { Trash2, Pencil, Wallet, Coins, Plus, Copy, HandCoins } from 'lucide-svelte';
 	import { page } from '$app/state';
 
 	// Api
@@ -28,6 +28,7 @@
 	import CreateGroupWallet from '$lib/components/modals/CreateGroupWallet.svelte';
 	import FundGroupWallet from '$lib/components/modals/FundGroupWallet.svelte';
 	import { shortenAddress } from '$lib/utils/address_utils';
+	import ProposeWithdrawModal from '$lib/components/modals/ProposeWithdrawModal.svelte';
 
 	// --- STATES ---
 	let loading = $state(true);
@@ -51,6 +52,8 @@
 	let showEditModal = $state(false);
 	let showCreateWalletModal = $state(false);
 	let showFundWalletModal = $state(false);
+	let showWithdrawModal = $state(false);
+	let selectedCurrencyIdToWithdraw = $state<string>('');
 	let selectedWalletIdToFund = $state<string>('');
 	let selectedCurrencyId = $state<string>('');
 
@@ -112,6 +115,11 @@
 		selectedWalletIdToFund = walletId;
 		selectedCurrencyId = currencyId;
 		showFundWalletModal = true;
+	}
+
+	function openWithdrawModal(currencyId: string) {
+		selectedCurrencyIdToWithdraw = currencyId;
+		showWithdrawModal = true;
 	}
 
 	loadGroupData();
@@ -267,7 +275,17 @@
 											</div>
 										</div>
 
-										<div>
+										<div class="flex items-center gap-2">
+											<Button
+												label="Retirar"
+												variant="secondary"
+												onclick={() => openWithdrawModal(wallet.currency_id)}
+											>
+												{#snippet icon()}
+													<HandCoins class="h-4 w-4" />
+												{/snippet}
+											</Button>
+
 											<Button
 												label="Fondear"
 												variant="secondary"
@@ -305,7 +323,7 @@
 				href="/dashboard"
 				class="text-sm font-medium text-gray-500 transition hover:text-black hover:underline"
 			>
-				← Back to Dashboard
+				← Volver al Dashboard
 			</a>
 		</div>
 
@@ -330,6 +348,17 @@
 				showFundWalletModal = false;
 				selectedWalletIdToFund = '';
 				selectedCurrencyId = '';
+			}}
+			onsuccess={loadWalletsData}
+		/>
+
+		<ProposeWithdrawModal
+			open={showWithdrawModal}
+			group_id={groupData.id}
+			currency_id={selectedCurrencyIdToWithdraw}
+			onclose={() => {
+				showWithdrawModal = false;
+				selectedCurrencyIdToWithdraw = '';
 			}}
 			onsuccess={loadWalletsData}
 		/>

--- a/client/src/routes/groups/[group_id]/+page.svelte
+++ b/client/src/routes/groups/[group_id]/+page.svelte
@@ -29,6 +29,7 @@
 	import FundGroupWallet from '$lib/components/modals/FundGroupWallet.svelte';
 	import { shortenAddress } from '$lib/utils/address_utils';
 	import ProposeWithdrawModal from '$lib/components/modals/ProposeWithdrawModal.svelte';
+	import WithdrawProposalDrawer from '$lib/components/WithdrawProposalDrawer.svelte';
 
 	// --- STATES ---
 	let loading = $state(true);
@@ -53,6 +54,7 @@
 	let showCreateWalletModal = $state(false);
 	let showFundWalletModal = $state(false);
 	let showWithdrawModal = $state(false);
+	let showProposalsDrawer = $state(false);
 	let selectedCurrencyIdToWithdraw = $state<string>('');
 	let selectedWalletIdToFund = $state<string>('');
 	let selectedCurrencyId = $state<string>('');
@@ -148,6 +150,15 @@
 					<div class="flex items-start justify-between gap-4">
 						<h1 class="text-2xl font-bold tracking-tight text-black">{groupData.name}</h1>
 						<div class="flex items-center gap-2">
+							<Button
+								label="Propuestas"
+								variant="secondary"
+								onclick={() => (showProposalsDrawer = true)}
+							>
+								{#snippet icon()}
+									<HandCoins class="h-4 w-4" />
+								{/snippet}
+							</Button>
 							{#if groupData.status}
 								<span
 									class="rounded border border-gray-200 bg-gray-50 px-2.5 py-1 text-xs font-medium text-gray-600"
@@ -368,6 +379,12 @@
 			group={groupData}
 			onclose={() => (showEditModal = false)}
 			onedit={handleEditGroup}
+		/>
+		<WithdrawProposalDrawer
+			open={showProposalsDrawer}
+			group_id={groupData.id}
+			onclose={() => (showProposalsDrawer = false)}
+			onsuccess={loadWalletsData}
 		/>
 		<Confirm
 			open={showDeleteModal}

--- a/server/src/handlers/proposal.rs
+++ b/server/src/handlers/proposal.rs
@@ -103,7 +103,6 @@ pub async fn get_all_withdraw_proposals(
 ) -> Result<Json<Vec<WithdrawProposalExpanded>>, AppError> {
     let withdraw_proposals = state
         .proposal_service
-        .get_all_withdraw_proposals(group_id)?
-        .unwrap_or_default();
+        .get_all_withdraw_proposals(group_id)?;
     Ok(Json(withdraw_proposals))
 }

--- a/server/src/handlers/proposal.rs
+++ b/server/src/handlers/proposal.rs
@@ -4,6 +4,7 @@ use crate::models::proposal::Proposal;
 use crate::models::proposals::new_member::{
     NewMemberProposalExpanded, ReceivedNewMemberProposalExpanded,
 };
+use crate::models::proposals::withdraw::{WithdrawProposal, WithdrawProposalExpanded};
 use crate::security::auth_extractor::AuthUser;
 use axum::extract::{Path, Query};
 use axum::{Json, extract::State};
@@ -93,4 +94,16 @@ pub async fn respond_to_user_proposal(
             .proposal_service
             .respond_new_member_proposal(user.user_id, proposal_id, payload)?;
     Ok(Json(update_proposal))
+}
+
+pub async fn get_all_withdraw_proposals(
+    State(state): State<SharedState>,
+    _user: AuthUser,
+    Path(group_id): Path<Uuid>,
+) -> Result<Json<Vec<WithdrawProposalExpanded>>, AppError> {
+    let withdraw_proposals = state
+        .proposal_service
+        .get_all_withdraw_proposals(group_id)?
+        .unwrap_or_default();
+    Ok(Json(withdraw_proposals))
 }

--- a/server/src/handlers/proposal.rs
+++ b/server/src/handlers/proposal.rs
@@ -4,7 +4,7 @@ use crate::models::proposal::Proposal;
 use crate::models::proposals::new_member::{
     NewMemberProposalExpanded, ReceivedNewMemberProposalExpanded,
 };
-use crate::models::proposals::withdraw::{WithdrawProposal, WithdrawProposalExpanded};
+use crate::models::proposals::withdraw::WithdrawProposalExpanded;
 use crate::security::auth_extractor::AuthUser;
 use axum::extract::{Path, Query};
 use axum::{Json, extract::State};

--- a/server/src/models/user_wallet.rs
+++ b/server/src/models/user_wallet.rs
@@ -32,5 +32,6 @@ pub struct WalletWithTickerDb {
     pub wallet_id: Uuid,
     pub address: String,
     pub balance: BigDecimal,
+    pub currency_id: Uuid,
     pub ticker: String,
 }

--- a/server/src/repositories/diesel/proposal_repo_impl.rs
+++ b/server/src/repositories/diesel/proposal_repo_impl.rs
@@ -328,4 +328,31 @@ impl ProposalRepository for DieselProposalRepository {
             proposal_type: ProposalType::Withdraw,
         }))
     }
+
+    fn get_all_withdraw_proposals(
+        &self,
+        group_id: Uuid,
+    ) -> Result<Option<Vec<WithdrawProposalExpanded>>, DbError> {
+        let mut conn = self.db.get_conn()?;
+
+        let results = withdraw_proposal::table
+            .inner_join(proposal::table.on(withdraw_proposal::proposal_id.eq(proposal::id)))
+            .filter(proposal::group_id.eq(group_id))
+            .load::<(WithdrawProposal, Proposal)>(&mut conn)?;
+
+        if results.is_empty() {
+            return Ok(None);
+        }
+
+        let expanded_proposals = results
+            .into_iter()
+            .map(|(wp, p)| WithdrawProposalExpanded {
+                proposal: p,
+                withdraw_proposal: wp,
+                proposal_type: ProposalType::Withdraw,
+            })
+            .collect();
+
+        Ok(Some(expanded_proposals))
+    }
 }

--- a/server/src/repositories/diesel/user_wallet_repo_impl.rs
+++ b/server/src/repositories/diesel/user_wallet_repo_impl.rs
@@ -168,6 +168,7 @@ impl UserWalletRepository for DieselUserWalletRepository {
                 user_wallet::id,
                 user_wallet::address,
                 user_wallet::balance,
+                currency::currency_id,
                 currency::ticker,
             ))
             .load::<WalletWithTickerDb>(&mut conn)?;

--- a/server/src/repositories/traits/proposal_repo.rs
+++ b/server/src/repositories/traits/proposal_repo.rs
@@ -6,7 +6,7 @@ use crate::models::proposal::{MyProposalStatus, NewProposal, Proposal, ProposalU
 use crate::models::proposals::new_member::{
     NewMemberProposalExpanded, ReceivedNewMemberProposalExpanded,
 };
-use crate::models::proposals::withdraw::WithdrawProposalExpanded;
+use crate::models::proposals::withdraw::{WithdrawProposal, WithdrawProposalExpanded};
 
 pub trait ProposalRepository: Send + Sync {
     fn find_by_group(&self, group_id: Uuid) -> Result<Vec<NewMemberProposalExpanded>, DbError>;
@@ -63,4 +63,9 @@ pub trait ProposalRepository: Send + Sync {
         proposal_id: Uuid,
         currency_id: Uuid,
     ) -> Result<Option<WithdrawProposalExpanded>, DbError>;
+
+    fn get_all_withdraw_proposals(
+        &self,
+        group_id: Uuid,
+    ) -> Result<Option<Vec<WithdrawProposalExpanded>>, DbError>;
 }

--- a/server/src/repositories/traits/proposal_repo.rs
+++ b/server/src/repositories/traits/proposal_repo.rs
@@ -6,7 +6,7 @@ use crate::models::proposal::{MyProposalStatus, NewProposal, Proposal, ProposalU
 use crate::models::proposals::new_member::{
     NewMemberProposalExpanded, ReceivedNewMemberProposalExpanded,
 };
-use crate::models::proposals::withdraw::{WithdrawProposal, WithdrawProposalExpanded};
+use crate::models::proposals::withdraw::WithdrawProposalExpanded;
 
 pub trait ProposalRepository: Send + Sync {
     fn find_by_group(&self, group_id: Uuid) -> Result<Vec<NewMemberProposalExpanded>, DbError>;

--- a/server/src/routes/proposal.rs
+++ b/server/src/routes/proposal.rs
@@ -3,8 +3,8 @@ use axum::{Router, middleware};
 
 use crate::data::state::SharedState;
 use crate::handlers::proposal::{
-    delete_proposal, group_proposals, my_proposals, new_group_member, received_proposals,
-    respond_to_user_proposal,
+    delete_proposal, get_all_withdraw_proposals, group_proposals, my_proposals, new_group_member,
+    received_proposals, respond_to_user_proposal,
 };
 
 use crate::security::middlewares::auth::auth_middleware;
@@ -18,10 +18,18 @@ pub fn proposal_routes(state: SharedState) -> Router {
         .route("/my", get(my_proposals))
         // Get proposals sent to Me
         .route("/received", get(received_proposals))
-        // Get Proposals by Group
+        // Get NewMember proposals by Group
         .route(
             "/group/{id}",
             get(group_proposals).route_layer(middleware::from_fn_with_state(
+                state.clone(),
+                is_in_group_middleware,
+            )),
+        )
+        //get all withdraw proposals
+        .route(
+            "/withdraw/{group_id}",
+            get(get_all_withdraw_proposals).route_layer(middleware::from_fn_with_state(
                 state.clone(),
                 is_in_group_middleware,
             )),

--- a/server/src/services/proposal.rs
+++ b/server/src/services/proposal.rs
@@ -8,7 +8,7 @@ use crate::models::proposal::{MyProposalStatus, NewProposal, Proposal, ProposalU
 use crate::models::proposals::new_member::{
     NewMemberProposalExpanded, ReceivedNewMemberProposalExpanded,
 };
-
+use crate::models::proposals::withdraw::WithdrawProposalExpanded;
 // Repos
 use crate::repositories::traits::group_repo::GroupRepository;
 use crate::repositories::traits::proposal_repo::ProposalRepository;
@@ -35,7 +35,7 @@ impl ProposalService {
     }
 
     /// # Get proposals of group
-    /// Returns a Vector of proposals bound to a group
+    /// Returns a Vector of new member proposals bound to a group
     ///
     /// ### Errors
     ///
@@ -230,5 +230,14 @@ impl ProposalService {
         self.group_repo
             .find_by_id(group_id)?
             .ok_or(AppError::BadRequest("Group does not exist".to_string()))
+    }
+
+    pub fn get_all_withdraw_proposals(
+        &self,
+        group_id: Uuid,
+    ) -> Result<Option<Vec<WithdrawProposalExpanded>>, AppError> {
+        self.proposal_repo
+            .get_all_withdraw_proposals(group_id)
+            .map_err(AppError::Db)
     }
 }

--- a/server/src/services/proposal.rs
+++ b/server/src/services/proposal.rs
@@ -235,9 +235,10 @@ impl ProposalService {
     pub fn get_all_withdraw_proposals(
         &self,
         group_id: Uuid,
-    ) -> Result<Option<Vec<WithdrawProposalExpanded>>, AppError> {
+    ) -> Result<Vec<WithdrawProposalExpanded>, AppError> {
         self.proposal_repo
             .get_all_withdraw_proposals(group_id)
+            .map(|proposals| proposals.unwrap_or_default())
             .map_err(AppError::Db)
     }
 }

--- a/server/src/services/user_wallet.rs
+++ b/server/src/services/user_wallet.rs
@@ -256,6 +256,7 @@ impl UserWalletService {
             let detail = WalletWithTickerDb {
                 address: wallet_row.address.to_string(),
                 wallet_id: wallet_row.wallet_id,
+                currency_id: wallet_row.currency_id,
                 ticker: wallet_row.ticker,
                 balance: wallet_row.balance,
             };


### PR DESCRIPTION
This pull request introduces the complete workflow for proposing, listing, and executing group wallet withdrawal proposals in the application. It includes backend support, new API endpoints, data types, and frontend UI components for both proposing a withdrawal and managing/approving withdrawal proposals. The changes also add the necessary wiring to the group page, allowing users to interact with the new withdrawal proposal system.

**Withdrawal Proposal System Implementation**

*Backend support and API endpoints:*
- Added backend handler and service for fetching all withdrawal proposals for a group, and updated models to include `currency_id` in wallet data. (`server/src/handlers/proposal.rs`, `server/src/models/user_wallet.rs`) [[1]](diffhunk://#diff-781718cc9323370367365b9dd3d2ff887fc2ede067befee8102357df143d003cR7) [[2]](diffhunk://#diff-781718cc9323370367365b9dd3d2ff887fc2ede067befee8102357df143d003cR98-R109) [[3]](diffhunk://#diff-8eceee1cd21da1678889c368a3f4748f465f6c6c35930cbcbdaca0ad200fd574R35)

*API client and types:*
- Added new API client endpoints for proposing a withdrawal, listing withdrawal proposals, and executing a withdrawal proposal, along with corresponding TypeScript types. (`client/src/lib/api/endpoints/transactions.ts`, `client/src/lib/types/endpoints/transactions.types.ts`) [[1]](diffhunk://#diff-d35342a1344dcb8f1aa8c0bc63b4ec48274c2229681e83f7481c2181e277059cR1-R41) [[2]](diffhunk://#diff-63d6d0e4c892d540e1ac007f01f58a633170af10e499571a06b6b04aa3a2346eR1-R39)
- Updated `WalletCurrency` type to include `currency_id`. (`client/src/lib/types/endpoints/wallets.types.ts`)
- Imported new types where necessary for proposal endpoints. (`client/src/lib/api/endpoints/proposals.ts`)

*Frontend UI components:*
- Added `ProposeWithdrawModal.svelte` for proposing a new withdrawal, including wallet selection and amount validation. (`client/src/lib/components/modals/ProposeWithdrawModal.svelte`)
- Added `WithdrawProposalDrawer.svelte` for listing, viewing, and executing withdrawal proposals, with support for filtering compatible wallets and handling execution state. (`client/src/lib/components/WithdrawProposalDrawer.svelte`)

*Integration with group page:*
- Integrated withdrawal proposal actions into the group page: added "Retirar" (Withdraw) and "Propuestas" (Proposals) buttons, modal/drawer state management, and modal invocation logic. (`client/src/routes/groups/[group_id]/+page.svelte`) ([client/src/routes/groups/[group_id]/+page.svelteL2-R2](diffhunk://#diff-470d0fa598457e2e16d9f8810874ad1a40e01b1e2539d5da2de5a0166bbb695bL2-R2), [client/src/routes/groups/[group_id]/+page.svelteR31-R32](diffhunk://#diff-470d0fa598457e2e16d9f8810874ad1a40e01b1e2539d5da2de5a0166bbb695bR31-R32), [client/src/routes/groups/[group_id]/+page.svelteR56-R58](diffhunk://#diff-470d0fa598457e2e16d9f8810874ad1a40e01b1e2539d5da2de5a0166bbb695bR56-R58), [client/src/routes/groups/[group_id]/+page.svelteR122-R126](diffhunk://#diff-470d0fa598457e2e16d9f8810874ad1a40e01b1e2539d5da2de5a0166bbb695bR122-R126), [client/src/routes/groups/[group_id]/+page.svelteR153-R161](diffhunk://#diff-470d0fa598457e2e16d9f8810874ad1a40e01b1e2539d5da2de5a0166bbb695bR153-R161), [client/src/routes/groups/[group_id]/+page.svelteL270-R299](diffhunk://#diff-470d0fa598457e2e16d9f8810874ad1a40e01b1e2539d5da2de5a0166bbb695bL270-R299), [client/src/routes/groups/[group_id]/+page.svelteL308-R337](diffhunk://#diff-470d0fa598457e2e16d9f8810874ad1a40e01b1e2539d5da2de5a0166bbb695bL308-R337), [client/src/routes/groups/[group_id]/+page.svelteR366-R388](diffhunk://#diff-470d0fa598457e2e16d9f8810874ad1a40e01b1e2539d5da2de5a0166bbb695bR366-R388))

These changes collectively enable users to propose withdrawals from group wallets, view all pending withdrawal proposals, and execute approved proposals, completing the group withdrawal proposal workflow.