### PR TITLE
Feature: frontend para crear, ver, borrar y contribuir a fund round proposals

### DIFF
--- a/client/src/lib/api/endpoints/fund_rounds.ts
+++ b/client/src/lib/api/endpoints/fund_rounds.ts
@@ -6,6 +6,7 @@ import type {
 	CreateFundRoundData,
 	FundRoundContribution,
 	FundRoundProposalExpanded,
+	FundRoundRemainingResponse,
 	FundRoundStatusResponse
 } from '$lib/types/endpoints/fund_rounds.types';
 
@@ -60,5 +61,13 @@ export async function cancelFundRoundProposal(
 ): ApiResponse<FundRoundProposalExpanded> {
 	return authedApiFetch(`/group-wallet/fund-round/${fund_round_id}/cancel`, {
 		method: 'DELETE'
+	});
+}
+
+export async function getFundRoundRemaining(
+	fund_round_id: string
+): ApiResponse<FundRoundRemainingResponse> {
+	return authedApiFetch(`/group-wallet/fund-round/${fund_round_id}/remaining`, {
+		method: 'GET'
 	});
 }

--- a/client/src/lib/api/endpoints/fund_rounds.ts
+++ b/client/src/lib/api/endpoints/fund_rounds.ts
@@ -1,0 +1,64 @@
+import { authedApiFetch } from '../client';
+
+import type { ApiResponse } from '$lib/types/client.types';
+import type {
+	ContributeFundRoundData,
+	CreateFundRoundData,
+	FundRoundContribution,
+	FundRoundProposalExpanded,
+	FundRoundStatusResponse
+} from '$lib/types/endpoints/fund_rounds.types';
+
+export async function createFundRoundProposal(
+	data: CreateFundRoundData
+): ApiResponse<FundRoundProposalExpanded> {
+	return authedApiFetch(`/group-wallet/fund-round/create/${data.group_id}`, {
+		method: 'POST',
+		body: JSON.stringify({
+			target_amount: data.target_amount,
+			currency_id: data.currency_id
+		})
+	});
+}
+
+export async function contributeFundRound(
+	fund_round_id: string,
+	data: ContributeFundRoundData
+): ApiResponse<FundRoundStatusResponse> {
+	return authedApiFetch(`/group-wallet/fund-round/${fund_round_id}/contribute`, {
+		method: 'POST',
+		body: JSON.stringify(data)
+	});
+}
+
+export async function getMyFundRoundContribution(
+	fund_round_id: string
+): ApiResponse<FundRoundContribution> {
+	return authedApiFetch(`/group-wallet/fund-round/${fund_round_id}/contribute`, {
+		method: 'GET'
+	});
+}
+
+export async function getGroupFundRoundProposals(
+	group_id: string
+): ApiResponse<FundRoundProposalExpanded[]> {
+	return authedApiFetch(`/group-wallet/fund-round/${group_id}/get-all`, {
+		method: 'GET'
+	});
+}
+
+export async function getFundRoundProposal(
+	fund_round_id: string
+): ApiResponse<FundRoundStatusResponse> {
+	return authedApiFetch(`/group-wallet/fund-round/${fund_round_id}`, {
+		method: 'GET'
+	});
+}
+
+export async function cancelFundRoundProposal(
+	fund_round_id: string
+): ApiResponse<FundRoundProposalExpanded> {
+	return authedApiFetch(`/group-wallet/fund-round/${fund_round_id}/cancel`, {
+		method: 'DELETE'
+	});
+}

--- a/client/src/lib/components/modals/CreateFundRound.svelte
+++ b/client/src/lib/components/modals/CreateFundRound.svelte
@@ -1,0 +1,177 @@
+<script lang="ts">
+	import Modal from '$lib/components/modals/Modal.svelte';
+	import Button from '$lib/components/ui/Button.svelte';
+	import FormField from '$lib/components/ui/FormField.svelte';
+	import { X } from 'lucide-svelte';
+
+	import { createFundRoundProposal } from '$lib/api/endpoints/fund_rounds';
+	import { getGroupWallets } from '$lib/api/endpoints/groups';
+	import { isSuccess } from '$lib/types/client.types';
+	import type { GroupWallet } from '$lib/types/endpoints/groups.types';
+
+	interface Props {
+		open: boolean;
+		group_id: string;
+		onclose: () => void;
+		onsuccess?: () => void;
+	}
+
+	const { open, group_id, onclose, onsuccess }: Props = $props();
+
+	let groupWallets = $state<GroupWallet[]>([]);
+	let loadingWallets = $state(false);
+	let selectedCurrencyId = $state('');
+	let targetAmount = $state('');
+	let attempted = $state(false);
+	let error = $state('');
+	let success = $state('');
+	let loading = $state(false);
+
+	const currencySelected = $derived(selectedCurrencyId !== '');
+	const amountValid = $derived(
+		targetAmount != null &&
+			targetAmount !== '' &&
+			!isNaN(Number(String(targetAmount).replace(',', '.'))) &&
+			Number(String(targetAmount).replace(',', '.')) > 0
+	);
+	const formValid = $derived(currencySelected && amountValid);
+
+	async function loadGroupWallets() {
+		loadingWallets = true;
+		const res = await getGroupWallets(group_id);
+		loadingWallets = false;
+		if (!isSuccess(res)) {
+			error = 'No se pudieron cargar las billeteras del grupo.';
+			return;
+		}
+		groupWallets = res.body;
+	}
+
+	$effect(() => {
+		if (open) {
+			loadGroupWallets();
+		}
+	});
+
+	async function handleSubmit(e: SubmitEvent) {
+		e.preventDefault();
+		attempted = true;
+		if (!formValid) return;
+
+		error = '';
+		success = '';
+		loading = true;
+
+		const response = await createFundRoundProposal({
+			group_id,
+			currency_id: selectedCurrencyId,
+			target_amount: String(targetAmount).replace(',', '.')
+		});
+
+		loading = false;
+
+		if (!isSuccess(response)) {
+			error = response.message || 'Error al crear la ronda de fondeo.';
+			return;
+		}
+
+		success = 'Ronda de fondeo creada exitosamente!';
+
+		setTimeout(() => {
+			handleClose();
+			onsuccess?.();
+		}, 1200);
+	}
+
+	function handleClose() {
+		selectedCurrencyId = '';
+		targetAmount = '';
+		attempted = false;
+		error = '';
+		success = '';
+		loading = false;
+		groupWallets = [];
+		onclose();
+	}
+</script>
+
+<Modal
+	{open}
+	title="Nueva ronda de fondeo"
+	description="Proponé un objetivo de fondeo asociado a una billetera del grupo."
+	onclose={handleClose}
+	{error}
+	{success}
+	{loading}
+>
+	{#snippet children()}
+		<form id="create-fund-round-form" onsubmit={handleSubmit} class="space-y-4">
+			<div>
+				<label for="fund-round-currency" class="mb-1.5 block text-sm font-medium text-black">
+					Moneda
+				</label>
+
+				{#if loadingWallets}
+					<div class="flex items-center gap-2 py-2">
+						<div
+							class="h-4 w-4 animate-spin rounded-full border-2 border-gray-200 border-t-black"
+						></div>
+						<span class="text-sm text-gray-400">Cargando billeteras del grupo...</span>
+					</div>
+				{:else if groupWallets.length === 0}
+					<p class="rounded-md border border-gray-200 bg-gray-50 p-3 text-sm text-gray-500">
+						El grupo no tiene billeteras aún. Creá una antes de abrir una ronda de fondeo.
+					</p>
+				{:else}
+					<select
+						id="fund-round-currency"
+						bind:value={selectedCurrencyId}
+						class="w-full rounded-md border px-3 py-2 text-sm text-black transition focus:ring-0 focus:outline-none
+							{attempted && !currencySelected
+							? 'border-red-400 focus:border-red-500'
+							: selectedCurrencyId
+								? 'border-green-400 focus:border-green-500'
+								: 'border-gray-200 focus:border-gray-400'}"
+					>
+						<option value="" disabled>Elegí una moneda</option>
+						{#each groupWallets as wallet (wallet.id)}
+							<option value={wallet.currency_id}>
+								{wallet.currency_ticker ?? 'USDC'} (saldo: ${wallet.balance})
+							</option>
+						{/each}
+					</select>
+
+					{#if attempted && !currencySelected}
+						<p class="mt-1.5 flex items-center gap-1 text-xs text-red-500">
+							<X class="h-3.5 w-3.5 shrink-0" />
+							Seleccioná una moneda
+						</p>
+					{/if}
+				{/if}
+			</div>
+
+			<FormField
+				id="fund-round-target"
+				label="Objetivo"
+				minLength={0}
+				maxLength={30}
+				type="number"
+				placeholder="0.00"
+				bind:value={targetAmount}
+				{attempted}
+			/>
+		</form>
+	{/snippet}
+
+	{#snippet footer()}
+		<Button label="Cancelar" variant="secondary" onclick={handleClose} />
+
+		<Button
+			label="Crear ronda"
+			type="submit"
+			form="create-fund-round-form"
+			disabled={!formValid}
+			{loading}
+		/>
+	{/snippet}
+</Modal>

--- a/client/src/lib/types/endpoints/fund_rounds.types.ts
+++ b/client/src/lib/types/endpoints/fund_rounds.types.ts
@@ -40,3 +40,8 @@ export type ContributeFundRoundData = {
 	amount: string;
 	sender_wallet_id: string;
 };
+
+export type FundRoundRemainingResponse = {
+	remaining: string;
+	is_last_contributor: boolean;
+};

--- a/client/src/lib/types/endpoints/fund_rounds.types.ts
+++ b/client/src/lib/types/endpoints/fund_rounds.types.ts
@@ -1,0 +1,42 @@
+import type { Proposal } from '$lib/types/endpoints/proposals.types';
+
+type ProposalType = 'FundRound';
+
+export type FundRoundProposal = {
+	proposal_id: string;
+	target_amount: string;
+	currency_id: string;
+};
+
+export type FundRoundProposalExpanded = {
+	proposal: Proposal;
+	fund_round_proposal: FundRoundProposal;
+	proposal_type: ProposalType;
+};
+
+export type FundRoundStatusResponse = {
+	fund_round: FundRoundProposalExpanded;
+	total_contributed: string;
+	target_amount: string;
+	is_completed: boolean;
+};
+
+export type FundRoundContribution = {
+	fund_round_proposal_id: string;
+	user_id: string;
+	amount: string;
+	transaction_id: string;
+	created_at: string;
+	updated_at: string;
+};
+
+export type CreateFundRoundData = {
+	group_id: string;
+	target_amount: string;
+	currency_id: string;
+};
+
+export type ContributeFundRoundData = {
+	amount: string;
+	sender_wallet_id: string;
+};

--- a/client/src/lib/types/endpoints/proposals.types.ts
+++ b/client/src/lib/types/endpoints/proposals.types.ts
@@ -1,6 +1,6 @@
 type Uuid = string;
 
-type ProposalStatus =
+export type ProposalStatus =
 	| 'Pending'
 	| 'Approved'
 	| 'Rejected'

--- a/client/src/lib/utils/proposal_status.ts
+++ b/client/src/lib/utils/proposal_status.ts
@@ -1,0 +1,48 @@
+import type { ProposalStatus } from '$lib/types/endpoints/proposals.types';
+
+export type ProposalStatusDisplay = {
+	label: string;
+	// Tailwind classes for the badge wrapper (borde + fondo + texto).
+	classes: string;
+};
+
+// Mapeo del enum de ProposalStatus a su representación visual en el front.
+export function getProposalStatusDisplay(status: ProposalStatus): ProposalStatusDisplay {
+	switch (status) {
+		case 'Approved':
+			return {
+				label: 'En curso',
+				classes: 'border-blue-200 bg-blue-50 text-blue-700'
+			};
+		case 'Executed':
+			return {
+				label: 'Finalizada',
+				classes: 'border-green-200 bg-green-50 text-green-700'
+			};
+		case 'Canceled':
+			return {
+				label: 'Cancelada',
+				classes: 'border-red-200 bg-red-50 text-red-600'
+			};
+		case 'Pending':
+			return {
+				label: 'Pendiente',
+				classes: 'border-gray-200 bg-gray-50 text-gray-600'
+			};
+		case 'Rejected':
+			return {
+				label: 'Rechazada',
+				classes: 'border-red-200 bg-red-50 text-red-600'
+			};
+		case 'Expired':
+			return {
+				label: 'Expirada',
+				classes: 'border-gray-200 bg-gray-50 text-gray-600'
+			};
+		case 'Failed':
+			return {
+				label: 'Fallida',
+				classes: 'border-red-200 bg-red-50 text-red-600'
+			};
+	}
+}

--- a/client/src/routes/groups/[group_id]/+page.svelte
+++ b/client/src/routes/groups/[group_id]/+page.svelte
@@ -8,7 +8,12 @@
 		Copy,
 		HandCoins,
 		LogOut,
-		ChevronDown
+		ChevronDown,
+		CircleCheckBig,
+		Users,
+		Calendar,
+		Target,
+		Ban
 	} from 'lucide-svelte';
 	import { slide } from 'svelte/transition';
 	import { page } from '$app/state';
@@ -22,6 +27,18 @@
 		getGroupWallets,
 		leaveGroup
 	} from '$lib/api/endpoints/groups';
+	import {
+		cancelFundRoundProposal,
+		contributeFundRound,
+		getFundRoundProposal,
+		getFundRoundRemaining,
+		getGroupFundRoundProposals,
+		getMyFundRoundContribution
+	} from '$lib/api/endpoints/fund_rounds';
+	import { getMyWallets } from '$lib/api/endpoints/wallets';
+
+	// Stores
+	import { authStore } from '$lib/stores/auth';
 
 	// Helpers
 	import { isSuccess } from '$lib/types/client.types';
@@ -30,6 +47,8 @@
 	import type { Group } from '$lib/types/endpoints/groups.types';
 	import type { UserBadge } from '$lib/types/endpoints/auth.types';
 	import type { GroupWallet } from '$lib/types/endpoints/groups.types';
+	import type { FundRoundStatusResponse } from '$lib/types/endpoints/fund_rounds.types';
+	import type { WalletCurrency } from '$lib/types/endpoints/wallets.types';
 
 	// Components
 	import UserIconBadge from '$lib/components/UserIconBadge.svelte';
@@ -39,7 +58,9 @@
 	import EditGroup from '$lib/components/modals/EditGroup.svelte';
 	import CreateGroupWallet from '$lib/components/modals/CreateGroupWallet.svelte';
 	import FundGroupWallet from '$lib/components/modals/FundGroupWallet.svelte';
+	import CreateFundRound from '$lib/components/modals/CreateFundRound.svelte';
 	import { shortenAddress } from '$lib/utils/address_utils';
+	import { getProposalStatusDisplay } from '$lib/utils/proposal_status';
 	import ProposeWithdrawModal from '$lib/components/modals/ProposeWithdrawModal.svelte';
 	import WithdrawProposalDrawer from '$lib/components/WithdrawProposalDrawer.svelte';
 
@@ -68,6 +89,7 @@
 	let showLeaveModal = $state(false);
 	let showWithdrawModal = $state(false);
 	let showProposalsDrawer = $state(false);
+	let showCreateFundRoundModal = $state(false);
 	let selectedCurrencyIdToWithdraw = $state<string>('');
 	let selectedWalletIdToFund = $state<string>('');
 	let selectedCurrencyId = $state<string>('');
@@ -77,15 +99,50 @@
 	let leaveLoading = $state(false);
 	let leaveError = $state('');
 
-	// --- FUND ROUNDS MOCK STATE ---
-	let showFundRoundAccordion = $state(false);
-	let selectedFundWallet = $state('');
+	// --- FUND ROUNDS STATE ---
+	let fundRounds = $state<FundRoundStatusResponse[]>([]);
+	let loadingFundRounds = $state(true);
+	let fundRoundsError = $state('');
+	let userWallets = $state<WalletCurrency[]>([]);
+	// proposal_id -> amount aportado por el usuario actual (string BigDecimal)
+	let myContributions = $state<Record<string, string>>({});
+	let expandedFundRoundId = $state<string | null>(null);
+	let selectedContribWalletId = $state('');
+	let contribLoading = $state(false);
+	let contribError = $state('');
 
-	// Mock de rondas de fondeo
-	const mockFundRounds = [
-		{ id: 1, title: 'Ronda #1', goal: 500, raised: 375, currency: 'USDC' },
-		{ id: 2, title: 'Ronda #2', goal: 1000, raised: 200, currency: 'USDC' }
-	];
+	let showCancelFundRoundModal = $state(false);
+	let fundRoundToCancel = $state<string>('');
+	let cancelFundRoundLoading = $state(false);
+	let cancelFundRoundError = $state('');
+
+	let showPastFundRounds = $state(false);
+
+	const currentUserId = $derived($authStore.user?.id);
+
+	// Activas: las que todavía pueden recibir aportes o están a la espera.
+	// Pasadas: finalizadas, canceladas o que no pueden avanzar.
+	const activeFundRounds = $derived(
+		fundRounds.filter((r) => {
+			const s = r.fund_round.proposal.status;
+			return s === 'Pending' || s === 'Approved';
+		})
+	);
+	const pastFundRounds = $derived(
+		fundRounds.filter((r) => {
+			const s = r.fund_round.proposal.status;
+			return s !== 'Pending' && s !== 'Approved';
+		})
+	);
+
+	function recommendedAmount(target: string): number {
+		const n = Math.max(1, members.length);
+		return Number(target) / n;
+	}
+
+	function formatAmount(value: number): string {
+		return value.toFixed(2);
+	}
 
 	// --- LOGIC ---
 	async function handleEditGroup(data: { name: string; description: string }) {
@@ -139,6 +196,7 @@
 	}
 
 	async function loadWalletsData() {
+		loadingWallets = true;
 		try {
 			const res = await getGroupWallets(groupId);
 			if (!isSuccess(res)) return;
@@ -158,6 +216,148 @@
 		selectedCurrencyIdToWithdraw = currencyId;
 		showWithdrawModal = true;
 	}
+
+	async function loadFundRoundsData() {
+		loadingFundRounds = true;
+		fundRoundsError = '';
+
+		const [roundsRes, walletsRes] = await Promise.all([
+			getGroupFundRoundProposals(groupId),
+			getMyWallets()
+		]);
+
+		if (!isSuccess(roundsRes)) {
+			fundRoundsError = roundsRes.message || 'No se pudieron cargar las rondas de fondeo.';
+			loadingFundRounds = false;
+			return;
+		}
+
+		if (isSuccess(walletsRes)) {
+			userWallets = walletsRes.body.flatMap((group) => group.currencies);
+		}
+
+		// Traemos los totales aportados por cada ronda en paralelo
+		const statuses = await Promise.all(
+			roundsRes.body.map((round) => getFundRoundProposal(round.proposal.id))
+		);
+
+		fundRounds = statuses
+			.filter(isSuccess)
+			.map((res) => res.body)
+			.sort(
+				(a, b) =>
+					new Date(b.fund_round.proposal.created_at).getTime() -
+					new Date(a.fund_round.proposal.created_at).getTime()
+			);
+
+		// Traemos mi aporte actual para cada ronda activa (el endpoint solo responde en Approved)
+		const approved = fundRounds.filter((s) => s.fund_round.proposal.status === 'Approved');
+		const contribResponses = await Promise.all(
+			approved.map((s) => getMyFundRoundContribution(s.fund_round.proposal.id))
+		);
+
+		const nextContributions: Record<string, string> = {};
+		approved.forEach((s, i) => {
+			const res = contribResponses[i];
+			if (isSuccess(res)) {
+				nextContributions[s.fund_round.proposal.id] = res.body.amount;
+			}
+		});
+		myContributions = nextContributions;
+
+		loadingFundRounds = false;
+	}
+
+	function toggleFundRoundAccordion(fundRoundId: string) {
+		if (expandedFundRoundId === fundRoundId) {
+			expandedFundRoundId = null;
+		} else {
+			expandedFundRoundId = fundRoundId;
+		}
+		selectedContribWalletId = '';
+		contribError = '';
+	}
+
+	async function handleContribute(status: FundRoundStatusResponse) {
+		if (!selectedContribWalletId) return;
+
+		const proposalId = status.fund_round.proposal.id;
+
+		contribLoading = true;
+		contribError = '';
+
+		// Le preguntamos al backend (1) el monto EXACTO que falta y (2) si este usuario
+		// es el último miembro que aún no aportó. Si es el último, manda el remaining
+		// exacto para cerrar la ronda sin dejar centavos colgados por redondeos previos,
+		// aunque termine aportando un poquito más que los demás.
+		const remainingRes = await getFundRoundRemaining(proposalId);
+		if (!isSuccess(remainingRes)) {
+			contribLoading = false;
+			contribError = remainingRes.message || 'No se pudo calcular el monto a aportar.';
+			return;
+		}
+
+		const recommended = recommendedAmount(status.target_amount);
+		const { remaining: remainingStr, is_last_contributor } = remainingRes.body;
+
+		const amount = is_last_contributor ? remainingStr : formatAmount(recommended);
+
+		const res = await contributeFundRound(proposalId, {
+			amount,
+			sender_wallet_id: selectedContribWalletId
+		});
+
+		contribLoading = false;
+
+		if (!isSuccess(res)) {
+			contribError = res.message || 'Error al aportar a la ronda de fondeo.';
+			return;
+		}
+
+		expandedFundRoundId = null;
+		selectedContribWalletId = '';
+		await loadFundRoundsData();
+	}
+
+	function openCancelFundRoundModal(fundRoundId: string) {
+		fundRoundToCancel = fundRoundId;
+		cancelFundRoundError = '';
+		showCancelFundRoundModal = true;
+	}
+
+	async function handleCancelFundRound() {
+		if (!fundRoundToCancel) return;
+
+		cancelFundRoundLoading = true;
+		cancelFundRoundError = '';
+
+		const res = await cancelFundRoundProposal(fundRoundToCancel);
+
+		cancelFundRoundLoading = false;
+
+		if (!isSuccess(res)) {
+			cancelFundRoundError = res.message || 'Error al cancelar la ronda de fondeo.';
+			return;
+		}
+
+		showCancelFundRoundModal = false;
+		fundRoundToCancel = '';
+		await loadFundRoundsData();
+	}
+
+	// Recargamos las wallets del grupo cada vez que se entra a la pestaña "Billeteras"
+	$effect(() => {
+		if (activeTab === 'wallets') {
+			loadWalletsData();
+		}
+	});
+
+	// Recargamos las rondas de fondeo cada vez que se entra a la pestaña "Rondas de Fondeo"
+	$effect(() => {
+		if (activeTab === 'fund_rounds') {
+			loadFundRoundsData();
+		}
+	});
 
 	loadGroupData();
 	loadMembersData();
@@ -375,126 +575,356 @@
 				<!-- RONDAS DE FONDEO TAB -->
 				{#if activeTab === 'fund_rounds'}
 					<div class="animate-in fade-in slide-in-from-bottom-2 space-y-4 duration-300">
-						<div class="flex items-center justify-between">
-							<h2 class="text-sm font-medium text-black">Rondas de Fondeo</h2>
-							<Button label="Nueva Ronda" variant="primary">
+						<div class="flex items-start justify-between gap-4">
+							<div class="space-y-1">
+								<h2 class="text-sm font-medium text-black">Rondas de Fondeo</h2>
+								<p class="text-xs text-gray-500">
+									Aportes colectivos para fondear una billetera del grupo.
+								</p>
+							</div>
+							<Button
+								label="Nueva Ronda"
+								variant="primary"
+								onclick={() => (showCreateFundRoundModal = true)}
+							>
 								{#snippet icon()}
 									<Plus class="h-4 w-4" />
 								{/snippet}
 							</Button>
 						</div>
 
-						<div class="space-y-3 pt-2">
-							{#each mockFundRounds as round}
-								{@const progress = Math.round((round.raised / round.goal) * 100)}
-								{@const remaining = round.goal - round.raised}
-								{@const isOpen = showFundRoundAccordion && round.id === 1}
+						{#if fundRoundsError}
+							<div class="rounded-md bg-red-50 p-3 text-sm text-red-600">
+								{fundRoundsError}
+							</div>
+						{/if}
 
-								<div class="overflow-hidden rounded-lg border border-gray-200 bg-white">
-									<!-- Card principal -->
+						{#if loadingFundRounds}
+							<div
+								class="h-5 w-5 animate-spin rounded-full border-2 border-gray-200 border-t-black"
+							></div>
+						{:else if fundRounds.length === 0}
+							<div class="rounded-lg border border-dashed border-gray-300 p-8 text-center">
+								<HandCoins class="mx-auto mb-3 h-8 w-8 text-gray-400" />
+								<p class="text-sm font-medium text-black">Sin rondas de fondeo</p>
+								<p class="mb-4 text-sm text-gray-500">Este grupo no tiene rondas de fondeo aún.</p>
+								<Button
+									label="Crear primera ronda"
+									variant="secondary"
+									onclick={() => (showCreateFundRoundModal = true)}
+								/>
+							</div>
+						{:else}
+							{#snippet fundRoundCard(status: FundRoundStatusResponse)}
+								{@const proposalId = status.fund_round.proposal.id}
+								{@const proposalStatus = status.fund_round.proposal.status}
+								{@const target = Number(status.target_amount)}
+								{@const raised = Number(status.total_contributed)}
+								{@const progress =
+									target > 0 ? Math.min(100, Math.round((raised / target) * 100)) : 0}
+								{@const remaining = Math.max(0, target - raised)}
+								{@const ticker =
+									wallets.find(
+										(w) => w.currency_id === status.fund_round.fund_round_proposal.currency_id
+									)?.currency_ticker ?? 'USDC'}
+								{@const compatibleWallets = userWallets.filter(
+									(w) => w.currency_id === status.fund_round.fund_round_proposal.currency_id
+								)}
+								{@const recommended = recommendedAmount(status.target_amount)}
+								{@const myContribution = Number(myContributions[proposalId] ?? '0')}
+								{@const hasContributed = myContribution > 0}
+								{@const myRemaining = Math.max(0, recommended - myContribution)}
+								{@const canContribute =
+									proposalStatus === 'Approved' && !status.is_completed && !hasContributed}
+								{@const isCreator =
+									!!currentUserId && status.fund_round.proposal.created_by === currentUserId}
+								{@const canCancel =
+									isCreator && proposalStatus === 'Approved' && !status.is_completed}
+								{@const statusDisplay = getProposalStatusDisplay(proposalStatus)}
+								{@const isOpen = expandedFundRoundId === proposalId}
+
+								<div
+									class="group rounded-xl border border-gray-200 bg-white transition hover:border-gray-300 hover:shadow-sm"
+								>
 									<div class="space-y-4 p-5">
-										<!-- Fila superior: título + objetivo -->
-										<div class="flex items-start justify-between gap-2">
-											<div>
-												<p class="text-xs font-medium tracking-wider text-gray-400 uppercase">
-													{round.title}
-												</p>
-												<p class="mt-0.5 text-xl font-bold text-black">
-													${round.goal}
-													<span class="ml-1 text-sm font-medium text-gray-500"
-														>{round.currency}</span
-													>
-												</p>
-											</div>
-											<span
-												class="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-600"
-											>
-												{progress}%
-											</span>
-										</div>
-
-										<!-- Progress bar minimalista -->
-										<div class="h-2 w-full overflow-hidden rounded-full bg-gray-100">
-											<div
-												class="h-full rounded-full bg-black transition-all duration-700"
-												style="width: {progress}%"
-											></div>
-										</div>
-
-										<!-- Fila inferior: info + botón -->
-										<div class="flex items-center justify-between gap-4">
-											<p class="text-xs text-gray-500">
-												<span class="font-medium text-gray-700">{progress}% completado</span>
-												&mdash; Faltan
-												<span class="font-medium text-gray-700">${remaining} {round.currency}</span>
-											</p>
-
-											<button
-												onclick={() =>
-													(showFundRoundAccordion =
-														round.id === 1 ? !showFundRoundAccordion : true)}
-												class="flex items-center gap-1.5 rounded-md bg-black px-3.5 py-2 text-xs font-medium text-white transition hover:bg-gray-800 active:scale-95"
-											>
-												Aportar mi parte
-												<ChevronDown
-													class={[
-														'h-3.5 w-3.5 transition-transform duration-200',
-														isOpen ? 'rotate-180' : ''
-													].join(' ')}
-												/>
-											</button>
-										</div>
-									</div>
-
-									<!-- Panel acordeón -->
-									{#if isOpen}
-										<div
-											transition:slide={{ duration: 220 }}
-											class="space-y-4 border-t border-gray-100 bg-gray-50 px-5 py-4"
-										>
-											<p class="text-xs font-medium tracking-wider text-gray-500 uppercase">
-												Elegí tu wallet para aportar
-											</p>
-
-											<div class="space-y-3">
-												<select
-													bind:value={selectedFundWallet}
-													class="w-full rounded-md border border-gray-200 bg-white px-3 py-2.5 text-sm text-black transition outline-none focus:border-black focus:ring-1 focus:ring-black"
+										<div class="flex items-start justify-between gap-3">
+											<div class="flex items-start gap-3">
+												<div
+													class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-gray-200 bg-gray-50 text-gray-700"
 												>
-													<option value="" disabled selected>Seleccionar wallet personal...</option>
-													{#each wallets as wallet}
-														<option value={wallet.id}>
-															{shortenAddress(wallet.address)} — ${wallet.balance}
-															{wallet.currency_ticker ?? 'USDC'}
-														</option>
-													{/each}
-													<!-- Fallback mock si no hay wallets cargadas -->
-													{#if wallets.length === 0}
-														<option value="mock-1">0xABCD...1234 — $200.00 USDC</option>
-														<option value="mock-2">0xEFGH...5678 — $50.00 USDC</option>
-													{/if}
-												</select>
-
-												<div class="flex items-center justify-end gap-2">
-													<button
-														onclick={() => (showFundRoundAccordion = false)}
-														class="rounded-md px-3.5 py-2 text-xs font-medium text-gray-500 transition hover:text-black"
+													<HandCoins class="h-5 w-5" />
+												</div>
+												<div class="space-y-1">
+													<div class="flex items-baseline gap-1.5">
+														<span class="text-2xl font-bold tracking-tight text-black"
+															>${target}</span
+														>
+														<span
+															class="rounded bg-black px-1.5 py-0.5 text-[10px] font-bold tracking-wider text-white uppercase"
+														>
+															{ticker}
+														</span>
+													</div>
+													<p
+														class="flex items-center gap-1 text-[11px] font-medium tracking-wide text-gray-400"
 													>
-														Cancelar
-													</button>
-													<button
-														class="rounded-md bg-black px-4 py-2 text-xs font-medium text-white transition hover:bg-gray-800 active:scale-95 disabled:opacity-40"
-														disabled={!selectedFundWallet}
-													>
-														Confirmar Aporte
-													</button>
+														<Calendar class="h-3 w-3" />
+														{new Date(status.fund_round.proposal.created_at).toLocaleDateString(
+															'es-AR',
+															{
+																day: '2-digit',
+																month: 'short',
+																year: 'numeric'
+															}
+														)}
+													</p>
 												</div>
 											</div>
+
+											<div class="flex shrink-0 items-center gap-1.5">
+												<span
+													class="rounded-full border px-2.5 py-1 text-xs font-medium {statusDisplay.classes}"
+												>
+													{statusDisplay.label}
+												</span>
+
+												{#if canCancel}
+													<div class="group/cancel relative flex">
+														<button
+															type="button"
+															onclick={() => openCancelFundRoundModal(proposalId)}
+															aria-label="Cancelar ronda"
+															class="flex h-7 w-7 items-center justify-center rounded-full border border-gray-200 bg-white text-gray-500 transition hover:border-red-200 hover:bg-red-50 hover:text-red-600 active:scale-95"
+														>
+															<Ban class="h-3.5 w-3.5" />
+														</button>
+
+														<span
+															class="pointer-events-none invisible absolute top-full right-0 z-50 mt-2 rounded-md bg-[#222327] px-2.5 py-1 text-xs font-medium whitespace-nowrap text-white opacity-0 shadow-sm transition-all duration-200 group-hover/cancel:visible group-hover/cancel:opacity-100"
+														>
+															Cancelar ronda
+														</span>
+													</div>
+												{/if}
+											</div>
+										</div>
+
+										<div class="space-y-2">
+											<div class="h-2 w-full overflow-hidden rounded-full bg-gray-100">
+												<div
+													class="h-full rounded-full bg-linear-to-r from-gray-800 to-black transition-all duration-700"
+													style="width: {progress}%"
+												></div>
+											</div>
+
+											<div class="flex items-center justify-between text-xs">
+												<span class="font-medium text-gray-700">
+													${formatAmount(raised)}
+													<span class="text-gray-400">/ ${formatAmount(target)} {ticker}</span>
+												</span>
+												<span class="text-gray-500">
+													<span class="font-medium text-gray-700">{progress}%</span>
+													{#if remaining > 0}
+														— faltan ${formatAmount(remaining)} {ticker}
+													{:else}
+														— completado
+													{/if}
+												</span>
+											</div>
+										</div>
+
+										{#if proposalStatus === 'Approved'}
+											<div
+												class="flex flex-col gap-3 rounded-lg border border-gray-100 bg-gray-50/70 px-3 py-2.5 text-xs sm:flex-row sm:items-center sm:justify-between"
+											>
+												<div class="flex items-start gap-2">
+													<Target class="mt-0.5 h-3.5 w-3.5 shrink-0 text-gray-400" />
+													<div class="space-y-0.5">
+														<p class="text-gray-500">
+															Te toca aportar
+															<span class="font-semibold text-black"
+																>${formatAmount(recommended)} {ticker}</span
+															>
+														</p>
+														{#if members.length > 0}
+															<p class="flex items-center gap-1 text-[11px] text-gray-400">
+																<Users class="h-3 w-3" />
+																${formatAmount(target)} entre {members.length}
+																{members.length === 1 ? 'miembro' : 'miembros'}
+															</p>
+														{/if}
+													</div>
+												</div>
+
+												<div class="flex items-center gap-4 self-stretch sm:self-auto">
+													{#if hasContributed}
+														<span
+															class="inline-flex flex-1 items-center justify-center gap-1 rounded-md border border-green-200 bg-green-50 px-2 py-1 font-medium text-green-700 sm:flex-none"
+														>
+															<CircleCheckBig class="h-3 w-3" />
+															Aportaste ${formatAmount(myContribution)}
+															{ticker}
+														</span>
+													{:else}
+														<span
+															class="flex-1 text-right font-medium text-gray-700 sm:flex-none sm:text-left"
+														>
+															Te falta ${formatAmount(myRemaining)}
+															{ticker}
+														</span>
+													{/if}
+
+													{#if canContribute}
+														<button
+															onclick={() => toggleFundRoundAccordion(proposalId)}
+															class="flex shrink-0 items-center gap-1.5 rounded-md bg-black px-3 py-1.5 text-xs font-medium text-white transition hover:bg-gray-800 active:scale-95"
+														>
+															Aportar
+															<ChevronDown
+																class={[
+																	'h-3.5 w-3.5 transition-transform duration-200',
+																	isOpen ? 'rotate-180' : ''
+																].join(' ')}
+															/>
+														</button>
+													{/if}
+												</div>
+											</div>
+										{/if}
+									</div>
+
+									{#if isOpen && canContribute}
+										<div
+											transition:slide={{ duration: 220 }}
+											class="space-y-4 overflow-hidden rounded-b-xl border-t border-gray-100 bg-gray-50/60 px-5 py-4"
+										>
+											<div class="space-y-1">
+												<p class="text-[11px] font-medium tracking-wider text-gray-500 uppercase">
+													Aportar a esta ronda
+												</p>
+												<p class="text-xs text-gray-500">
+													Elegí desde qué wallet personal salen los fondos.
+												</p>
+											</div>
+
+											{#if compatibleWallets.length === 0}
+												<div
+													class="flex items-start gap-2 rounded-md border border-gray-200 bg-white p-3 text-xs text-gray-500"
+												>
+													<Wallet class="mt-0.5 h-3.5 w-3.5 shrink-0 text-gray-400" />
+													<span>No tenés wallets compatibles con la moneda de esta ronda.</span>
+												</div>
+											{:else}
+												<div class="space-y-3">
+													<select
+														bind:value={selectedContribWalletId}
+														class="w-full rounded-md border border-gray-200 bg-white px-3 py-2.5 text-sm text-black transition outline-none focus:border-black focus:ring-1 focus:ring-black"
+													>
+														<option value="" disabled>Seleccionar wallet personal...</option>
+														{#each compatibleWallets as wallet (wallet.wallet_id)}
+															<option value={wallet.wallet_id}>
+																{shortenAddress(wallet.address)} — ${wallet.balance}
+																{wallet.ticker}
+															</option>
+														{/each}
+													</select>
+
+													<div
+														class="flex items-center justify-between rounded-md border border-gray-200 bg-white px-3 py-2.5 text-sm"
+													>
+														<span class="text-gray-500">Monto a aportar</span>
+														<span class="flex items-baseline gap-1.5">
+															<span class="font-semibold text-black">
+																${formatAmount(recommended)}
+															</span>
+															<span
+																class="rounded bg-black px-1.5 py-0.5 text-[10px] font-bold tracking-wider text-white uppercase"
+															>
+																{ticker}
+															</span>
+														</span>
+													</div>
+
+													{#if contribError}
+														<p class="text-xs text-red-500">{contribError}</p>
+													{/if}
+
+													<div class="flex items-center justify-end gap-2">
+														<button
+															onclick={() => toggleFundRoundAccordion(proposalId)}
+															class="rounded-md px-3.5 py-2 text-xs font-medium text-gray-500 transition hover:text-black"
+															disabled={contribLoading}
+														>
+															Cancelar
+														</button>
+														<button
+															onclick={() => handleContribute(status)}
+															class="rounded-md bg-black px-4 py-2 text-xs font-medium text-white transition hover:bg-gray-800 active:scale-95 disabled:opacity-40"
+															disabled={!selectedContribWalletId || contribLoading}
+														>
+															{contribLoading
+																? 'Enviando...'
+																: `Confirmar aporte de $${formatAmount(recommended)} ${ticker}`}
+														</button>
+													</div>
+												</div>
+											{/if}
 										</div>
 									{/if}
 								</div>
-							{/each}
-						</div>
+							{/snippet}
+
+							<div class="space-y-3 pt-2">
+								{#if activeFundRounds.length > 0}
+									{#each activeFundRounds as status (status.fund_round.proposal.id)}
+										{@render fundRoundCard(status)}
+									{/each}
+								{:else}
+									<div
+										class="flex flex-col items-center gap-1 rounded-xl border border-dashed border-gray-300 p-6 text-center"
+									>
+										<HandCoins class="h-6 w-6 text-gray-400" />
+										<p class="text-sm font-medium text-black">No hay rondas activas</p>
+										<p class="text-xs text-gray-500">
+											Todas las rondas están finalizadas o canceladas.
+										</p>
+									</div>
+								{/if}
+
+								{#if pastFundRounds.length > 0}
+									<div class="flex items-center gap-3 pt-4 pb-1">
+										<div class="h-px flex-1 bg-gray-200"></div>
+										<button
+											type="button"
+											onclick={() => (showPastFundRounds = !showPastFundRounds)}
+											class="inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-3 py-1 text-[11px] font-medium text-gray-600 transition hover:border-gray-300 hover:text-black"
+										>
+											{showPastFundRounds ? 'Ocultar' : 'Ver'} rondas pasadas
+											<span
+												class="rounded-full bg-gray-100 px-1.5 text-[10px] font-semibold text-gray-600"
+											>
+												{pastFundRounds.length}
+											</span>
+											<ChevronDown
+												class={[
+													'h-3 w-3 transition-transform duration-200',
+													showPastFundRounds ? 'rotate-180' : ''
+												].join(' ')}
+											/>
+										</button>
+										<div class="h-px flex-1 bg-gray-200"></div>
+									</div>
+
+									{#if showPastFundRounds}
+										<div transition:slide={{ duration: 220 }} class="space-y-3">
+											{#each pastFundRounds as status (status.fund_round.proposal.id)}
+												{@render fundRoundCard(status)}
+											{/each}
+										</div>
+									{/if}
+								{/if}
+							</div>
+						{/if}
 					</div>
 				{/if}
 			</div>
@@ -556,6 +986,12 @@
 			onclose={() => (showProposalsDrawer = false)}
 			onsuccess={loadWalletsData}
 		/>
+		<CreateFundRound
+			open={showCreateFundRoundModal}
+			group_id={groupData.id}
+			onclose={() => (showCreateFundRoundModal = false)}
+			onsuccess={loadFundRoundsData}
+		/>
 		<Confirm
 			open={showLeaveModal}
 			title="Salir del grupo"
@@ -581,6 +1017,20 @@
 			onconfirm={handleDeleteGroup}
 			loading={deleteLoading}
 			error={deleteError}
+		/>
+		<Confirm
+			open={showCancelFundRoundModal}
+			title="Cancelar ronda de fondeo"
+			description="Los aportes realizados no se devuelven automáticamente."
+			message="¿Seguro que querés cancelar esta ronda de fondeo?"
+			onclose={() => {
+				showCancelFundRoundModal = false;
+				cancelFundRoundError = '';
+				fundRoundToCancel = '';
+			}}
+			onconfirm={handleCancelFundRound}
+			loading={cancelFundRoundLoading}
+			error={cancelFundRoundError}
 		/>
 	{/if}
 </div>

--- a/client/src/routes/groups/[group_id]/+page.svelte
+++ b/client/src/routes/groups/[group_id]/+page.svelte
@@ -1,5 +1,16 @@
 <script lang="ts">
-	import { Trash2, Pencil, Wallet, Coins, Plus, Copy, HandCoins, LogOut } from 'lucide-svelte';
+	import {
+		Trash2,
+		Pencil,
+		Wallet,
+		Coins,
+		Plus,
+		Copy,
+		HandCoins,
+		LogOut,
+		ChevronDown
+	} from 'lucide-svelte';
+	import { slide } from 'svelte/transition';
 	import { page } from '$app/state';
 
 	// Api
@@ -44,8 +55,8 @@
 
 	const groupId = page.params.group_id as string;
 
-	// Sistema de Tabs nativo
-	type Tab = 'general' | 'wallets';
+	// Sistema de Tabs
+	type Tab = 'general' | 'wallets' | 'fund_rounds';
 	let activeTab = $state<Tab>('general');
 
 	// Modals
@@ -54,7 +65,7 @@
 	let showEditModal = $state(false);
 	let showCreateWalletModal = $state(false);
 	let showFundWalletModal = $state(false);
-	let showLeaveModal = $state(false); // Estado para el modal de salir
+	let showLeaveModal = $state(false);
 	let showWithdrawModal = $state(false);
 	let showProposalsDrawer = $state(false);
 	let selectedCurrencyIdToWithdraw = $state<string>('');
@@ -63,8 +74,18 @@
 
 	let deleteLoading = $state(false);
 	let deleteError = $state('');
-	let leaveLoading = $state(false); // Loading de salir
-	let leaveError = $state(''); // Error de salir
+	let leaveLoading = $state(false);
+	let leaveError = $state('');
+
+	// --- FUND ROUNDS MOCK STATE ---
+	let showFundRoundAccordion = $state(false);
+	let selectedFundWallet = $state('');
+
+	// Mock de rondas de fondeo
+	const mockFundRounds = [
+		{ id: 1, title: 'Ronda #1', goal: 500, raised: 375, currency: 'USDC' },
+		{ id: 2, title: 'Ronda #2', goal: 1000, raised: 200, currency: 'USDC' }
+	];
 
 	// --- LOGIC ---
 	async function handleEditGroup(data: { name: string; description: string }) {
@@ -85,7 +106,6 @@
 		window.location.href = '/dashboard';
 	}
 
-	// Nueva función para salir del grupo
 	async function handleLeaveGroup() {
 		leaveLoading = true;
 		leaveError = '';
@@ -121,9 +141,7 @@
 	async function loadWalletsData() {
 		try {
 			const res = await getGroupWallets(groupId);
-			if (!isSuccess(res)) {
-				return;
-			}
+			if (!isSuccess(res)) return;
 			wallets = res.body;
 		} finally {
 			loadingWallets = false;
@@ -150,7 +168,7 @@
 	<title>Lemipay - {groupData.name || 'Group'}</title>
 </svelte:head>
 
-<div class="flex min-h-[calc(100vh-64px)] flex-col items-center p-4 py-8">
+<div class="flex min-h-[calc(100vh-64px)] flex-col items-center px-4">
 	{#if loading}
 		<div
 			class="mt-20 h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-black"
@@ -161,86 +179,85 @@
 			<p class="text-sm text-gray-500">The group you are looking for does not exist.</p>
 		</div>
 	{:else}
-		<div class="w-full max-w-2xl rounded-xl border border-gray-200 bg-white shadow-sm">
-			<div class="p-6 pb-4 sm:p-8">
-				<div class="space-y-2">
-					<div class="flex items-start justify-between gap-4">
+		<!-- HEADER: fluye sobre el fondo, ancho extendido -->
+		<div class="w-full max-w-4xl border-b border-gray-200 pt-8 pb-6">
+			<div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+				<div class="space-y-1">
+					<div class="flex items-center gap-3">
 						<h1 class="text-2xl font-bold tracking-tight text-black">{groupData.name}</h1>
-						<div class="flex items-center gap-2">
-							<Button
-								label="Propuestas"
-								variant="secondary"
-								onclick={() => (showProposalsDrawer = true)}
+						{#if groupData.status}
+							<span
+								class="rounded border border-gray-200 bg-gray-50 px-2.5 py-1 text-xs font-medium text-gray-500"
 							>
-								{#snippet icon()}
-									<HandCoins class="h-4 w-4" />
-								{/snippet}
-							</Button>
-							{#if groupData.status}
-								<span
-									class="rounded border border-gray-200 bg-gray-50 px-2.5 py-1 text-xs font-medium text-gray-600"
-								>
-									{groupData.status}
-								</span>
-							{/if}
-
-							<button
-								onclick={() => (showEditModal = true)}
-								class="rounded-md p-1 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600"
-								title="Editar grupo"
-							>
-								<Pencil class="h-5 w-5" />
-							</button>
-
-							<button
-								onclick={() => (showLeaveModal = true)}
-								class="rounded-md p-1 text-gray-400 transition hover:bg-orange-50 hover:text-orange-500"
-								title="Salir del grupo"
-							>
-								<LogOut class="h-5 w-5" />
-							</button>
-
-							<button
-								onclick={() => (showDeleteModal = true)}
-								class="rounded-md p-1 text-gray-400 transition hover:bg-red-50 hover:text-red-500"
-								title="Eliminar grupo"
-							>
-								<Trash2 class="h-5 w-5" />
-							</button>
-						</div>
+								{groupData.status}
+							</span>
+						{/if}
 					</div>
 					{#if groupData.description}
 						<p class="text-sm leading-relaxed text-gray-500">{groupData.description}</p>
 					{/if}
 				</div>
+
+				<!-- Botones de acción -->
+				<div class="flex items-center gap-1 self-start">
+					<Button
+						label="Propuestas"
+						variant="secondary"
+						onclick={() => (showProposalsDrawer = true)}
+					>
+						{#snippet icon()}
+							<HandCoins class="h-4 w-4" />
+						{/snippet}
+					</Button>
+
+					<button
+						onclick={() => (showEditModal = true)}
+						class="rounded-md p-2 text-gray-400 transition hover:bg-gray-100 hover:text-gray-700"
+						title="Editar grupo"
+					>
+						<Pencil class="h-4 w-4" />
+					</button>
+
+					<button
+						onclick={() => (showLeaveModal = true)}
+						class="rounded-md p-2 text-gray-400 transition hover:bg-orange-50 hover:text-orange-500"
+						title="Salir del grupo"
+					>
+						<LogOut class="h-4 w-4" />
+					</button>
+
+					<button
+						onclick={() => (showDeleteModal = true)}
+						class="rounded-md p-2 text-gray-400 transition hover:bg-red-50 hover:text-red-500"
+						title="Eliminar grupo"
+					>
+						<Trash2 class="h-4 w-4" />
+					</button>
+				</div>
+			</div>
+		</div>
+
+		<!-- TABS NAV -->
+		<div class="w-full max-w-4xl">
+			<div class="flex border-b border-gray-200">
+				{#each [{ key: 'general', label: 'General' }, { key: 'wallets', label: 'Billeteras' }, { key: 'fund_rounds', label: 'Rondas de Fondeo' }] as const as tab}
+					<button
+						onclick={() => (activeTab = tab.key)}
+						class={[
+							'px-4 py-3 text-sm font-medium transition-colors',
+							activeTab === tab.key
+								? 'border-b-2 border-black text-black'
+								: 'text-gray-500 hover:text-black'
+						].join(' ')}
+					>
+						{tab.label}
+					</button>
+				{/each}
 			</div>
 
-			<div class="flex border-b border-gray-200 px-6 sm:px-8">
-				<button
-					onclick={() => (activeTab = 'general')}
-					class={[
-						'px-4 py-3 text-sm font-medium transition-colors',
-						activeTab === 'general'
-							? 'border-b-2 border-black text-black'
-							: 'text-gray-500 hover:text-black'
-					].join(' ')}
-				>
-					General
-				</button>
-				<button
-					onclick={() => (activeTab = 'wallets')}
-					class={[
-						'px-4 py-3 text-sm font-medium transition-colors',
-						activeTab === 'wallets'
-							? 'border-b-2 border-black text-black'
-							: 'text-gray-500 hover:text-black'
-					].join(' ')}
-				>
-					Billeteras
-				</button>
-			</div>
-
-			<div class="p-6 sm:p-8">
+			<!-- TAB CONTENT -->
+			<div class="py-8">
+				<!-- GENERAL TAB -->
 				{#if activeTab === 'general'}
 					<div class="animate-in fade-in slide-in-from-bottom-2 space-y-6 duration-300">
 						<div class="flex items-center justify-between">
@@ -272,6 +289,7 @@
 					</div>
 				{/if}
 
+				<!-- WALLETS TAB -->
 				{#if activeTab === 'wallets'}
 					<div class="animate-in fade-in slide-in-from-bottom-2 space-y-4 duration-300">
 						<div class="flex items-center justify-between">
@@ -295,7 +313,7 @@
 							<div class="space-y-3 pt-2">
 								{#each wallets as wallet}
 									<div
-										class="flex flex-col items-start justify-between gap-4 rounded-lg border border-gray-200 bg-gray-50/50 p-4 sm:flex-row sm:items-center"
+										class="flex flex-col items-start justify-between gap-4 rounded-lg border border-gray-200 bg-white p-4 sm:flex-row sm:items-center"
 									>
 										<div class="space-y-1">
 											<div class="flex items-center gap-2">
@@ -303,7 +321,6 @@
 												<span
 													class="rounded bg-black px-1.5 py-0.5 text-[10px] font-bold tracking-wider text-white uppercase"
 												>
-													<!-- ESTO ESTA HARDCODEADO TODO hacer que el back entregue tmb el ticker asi lo vemos aca-->
 													{wallet.currency_ticker ? wallet.currency_ticker : 'USDC'}
 												</span>
 											</div>
@@ -325,7 +342,6 @@
 													<HandCoins class="h-4 w-4" />
 												{/snippet}
 											</Button>
-
 											<Button
 												label="Fondear"
 												variant="secondary"
@@ -355,18 +371,146 @@
 						{/if}
 					</div>
 				{/if}
+
+				<!-- RONDAS DE FONDEO TAB -->
+				{#if activeTab === 'fund_rounds'}
+					<div class="animate-in fade-in slide-in-from-bottom-2 space-y-4 duration-300">
+						<div class="flex items-center justify-between">
+							<h2 class="text-sm font-medium text-black">Rondas de Fondeo</h2>
+							<Button label="Nueva Ronda" variant="primary">
+								{#snippet icon()}
+									<Plus class="h-4 w-4" />
+								{/snippet}
+							</Button>
+						</div>
+
+						<div class="space-y-3 pt-2">
+							{#each mockFundRounds as round}
+								{@const progress = Math.round((round.raised / round.goal) * 100)}
+								{@const remaining = round.goal - round.raised}
+								{@const isOpen = showFundRoundAccordion && round.id === 1}
+
+								<div class="overflow-hidden rounded-lg border border-gray-200 bg-white">
+									<!-- Card principal -->
+									<div class="space-y-4 p-5">
+										<!-- Fila superior: título + objetivo -->
+										<div class="flex items-start justify-between gap-2">
+											<div>
+												<p class="text-xs font-medium tracking-wider text-gray-400 uppercase">
+													{round.title}
+												</p>
+												<p class="mt-0.5 text-xl font-bold text-black">
+													${round.goal}
+													<span class="ml-1 text-sm font-medium text-gray-500"
+														>{round.currency}</span
+													>
+												</p>
+											</div>
+											<span
+												class="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-600"
+											>
+												{progress}%
+											</span>
+										</div>
+
+										<!-- Progress bar minimalista -->
+										<div class="h-2 w-full overflow-hidden rounded-full bg-gray-100">
+											<div
+												class="h-full rounded-full bg-black transition-all duration-700"
+												style="width: {progress}%"
+											></div>
+										</div>
+
+										<!-- Fila inferior: info + botón -->
+										<div class="flex items-center justify-between gap-4">
+											<p class="text-xs text-gray-500">
+												<span class="font-medium text-gray-700">{progress}% completado</span>
+												&mdash; Faltan
+												<span class="font-medium text-gray-700">${remaining} {round.currency}</span>
+											</p>
+
+											<button
+												onclick={() =>
+													(showFundRoundAccordion =
+														round.id === 1 ? !showFundRoundAccordion : true)}
+												class="flex items-center gap-1.5 rounded-md bg-black px-3.5 py-2 text-xs font-medium text-white transition hover:bg-gray-800 active:scale-95"
+											>
+												Aportar mi parte
+												<ChevronDown
+													class={[
+														'h-3.5 w-3.5 transition-transform duration-200',
+														isOpen ? 'rotate-180' : ''
+													].join(' ')}
+												/>
+											</button>
+										</div>
+									</div>
+
+									<!-- Panel acordeón -->
+									{#if isOpen}
+										<div
+											transition:slide={{ duration: 220 }}
+											class="space-y-4 border-t border-gray-100 bg-gray-50 px-5 py-4"
+										>
+											<p class="text-xs font-medium tracking-wider text-gray-500 uppercase">
+												Elegí tu wallet para aportar
+											</p>
+
+											<div class="space-y-3">
+												<select
+													bind:value={selectedFundWallet}
+													class="w-full rounded-md border border-gray-200 bg-white px-3 py-2.5 text-sm text-black transition outline-none focus:border-black focus:ring-1 focus:ring-black"
+												>
+													<option value="" disabled selected>Seleccionar wallet personal...</option>
+													{#each wallets as wallet}
+														<option value={wallet.id}>
+															{shortenAddress(wallet.address)} — ${wallet.balance}
+															{wallet.currency_ticker ?? 'USDC'}
+														</option>
+													{/each}
+													<!-- Fallback mock si no hay wallets cargadas -->
+													{#if wallets.length === 0}
+														<option value="mock-1">0xABCD...1234 — $200.00 USDC</option>
+														<option value="mock-2">0xEFGH...5678 — $50.00 USDC</option>
+													{/if}
+												</select>
+
+												<div class="flex items-center justify-end gap-2">
+													<button
+														onclick={() => (showFundRoundAccordion = false)}
+														class="rounded-md px-3.5 py-2 text-xs font-medium text-gray-500 transition hover:text-black"
+													>
+														Cancelar
+													</button>
+													<button
+														class="rounded-md bg-black px-4 py-2 text-xs font-medium text-white transition hover:bg-gray-800 active:scale-95 disabled:opacity-40"
+														disabled={!selectedFundWallet}
+													>
+														Confirmar Aporte
+													</button>
+												</div>
+											</div>
+										</div>
+									{/if}
+								</div>
+							{/each}
+						</div>
+					</div>
+				{/if}
 			</div>
 		</div>
 
-		<div class="pt-6">
+		<!-- Volver -->
+		<div class="w-full max-w-4xl pb-10">
 			<a
 				href="/dashboard"
-				class="text-sm font-medium text-gray-500 transition hover:text-black hover:underline"
+				class="text-sm font-medium text-gray-400 transition hover:text-black hover:underline"
 			>
 				← Volver al Dashboard
 			</a>
 		</div>
 
+		<!-- MODALS & DRAWERS (sin cambios) -->
 		<InviteUserToGroup
 			group_id={groupData.id}
 			open={showNewMemberModal}
@@ -378,7 +522,6 @@
 			group_id={groupData.id}
 			onclose={() => (showCreateWalletModal = false)}
 		/>
-
 		<FundGroupWallet
 			open={showFundWalletModal}
 			currency_id={selectedCurrencyId}
@@ -391,7 +534,6 @@
 			}}
 			onsuccess={loadWalletsData}
 		/>
-
 		<ProposeWithdrawModal
 			open={showWithdrawModal}
 			group_id={groupData.id}
@@ -402,7 +544,6 @@
 			}}
 			onsuccess={loadWalletsData}
 		/>
-
 		<EditGroup
 			open={showEditModal}
 			group={groupData}
@@ -415,7 +556,6 @@
 			onclose={() => (showProposalsDrawer = false)}
 			onsuccess={loadWalletsData}
 		/>
-
 		<Confirm
 			open={showLeaveModal}
 			title="Salir del grupo"
@@ -429,7 +569,6 @@
 			loading={leaveLoading}
 			error={leaveError}
 		/>
-
 		<Confirm
 			open={showDeleteModal}
 			title="Delete group"

--- a/server/src/handlers/group_wallet.rs
+++ b/server/src/handlers/group_wallet.rs
@@ -29,6 +29,15 @@ pub struct FundRoundStatusResponse {
     pub is_completed: bool,
 }
 
+#[derive(Serialize)]
+pub struct FundRoundRemainingResponse {
+    pub remaining: String,
+    // true si el que llama es el último miembro del grupo que aún no aportó.
+    // En ese caso, el cliente debe enviar `remaining` exacto para cerrar la ronda
+    // sin dejar centavos colgados por errores de redondeo previos.
+    pub is_last_contributor: bool,
+}
+
 pub async fn create_fund_round(
     State(state): State<SharedState>,
     user: AuthUser,
@@ -85,6 +94,21 @@ pub async fn cancel_fund_round(
         .group_wallet_service
         .cancel_fund_round(user.user_id, fund_round_id)?;
     Ok(Json(result))
+}
+
+pub async fn get_fund_round_remaining(
+    State(state): State<SharedState>,
+    user: AuthUser,
+    Path(fund_round_id): Path<Uuid>,
+) -> Result<Json<FundRoundRemainingResponse>, AppError> {
+    let (remaining, is_last_contributor) = state
+        .group_wallet_service
+        .get_fund_round_remaining(user.user_id, fund_round_id)?;
+
+    Ok(Json(FundRoundRemainingResponse {
+        remaining: remaining.to_string(),
+        is_last_contributor,
+    }))
 }
 
 #[derive(Deserialize)]

--- a/server/src/handlers/group_wallet.rs
+++ b/server/src/handlers/group_wallet.rs
@@ -111,3 +111,10 @@ pub async fn get_group_wallets(
     let wallets = state.group_wallet_service.get_wallets_by_group(group_id)?;
     Ok(Json(wallets))
 }
+pub async fn get_all_fund_rounds(
+    State(state): State<SharedState>,
+    Path(group_id): Path<Uuid>,
+) -> Result<Json<Vec<FundProposalExpanded>>, AppError> {
+    let result = state.group_wallet_service.get_all_fund_rounds(group_id)?;
+    Ok(Json(result))
+}

--- a/server/src/repositories/diesel/fund_round_repo_impl.rs
+++ b/server/src/repositories/diesel/fund_round_repo_impl.rs
@@ -286,4 +286,18 @@ impl FundRoundRepository for DieselFundRoundRepository {
 
         Ok(total.unwrap_or_default())
     }
+
+    // Cuenta la cantidad de usuarios distintos que aportaron a esta ronda.
+    // Como la regla de negocio actual es "un aporte por usuario por ronda",
+    // equivale a contar las filas de la tabla de contribuciones para esa ronda.
+    fn count_contributors(&self, fund_round_id: Uuid) -> Result<i64, DbError> {
+        let mut conn = self.db.get_conn()?;
+
+        let count: i64 = fund_round_contribution::table
+            .filter(fund_round_contribution::fund_round_proposal_id.eq(fund_round_id))
+            .count()
+            .get_result(&mut conn)?;
+
+        Ok(count)
+    }
 }

--- a/server/src/repositories/diesel/fund_round_repo_impl.rs
+++ b/server/src/repositories/diesel/fund_round_repo_impl.rs
@@ -99,6 +99,27 @@ impl FundRoundRepository for DieselFundRoundRepository {
         }))
     }
 
+    fn get_all_fund_round_proposals(
+        &self,
+        group_id: Uuid,
+    ) -> Result<Vec<FundProposalExpanded>, DbError> {
+        let mut conn = self.db.get_conn()?;
+
+        let result = fund_round_proposal::table
+            .inner_join(proposal::table.on(fund_round_proposal::proposal_id.eq(proposal::id)))
+            .filter(proposal::group_id.eq(group_id))
+            .load::<(FundProposal, Proposal)>(&mut conn)?;
+
+        Ok(result
+            .into_iter()
+            .map(|(frp, p)| FundProposalExpanded {
+                proposal: p,
+                fund_round_proposal: frp,
+                proposal_type: ProposalType::FundRound,
+            })
+            .collect())
+    }
+
     fn get_total_contributed(&self, fund_round_id: Uuid) -> Result<BigDecimal, DbError> {
         let mut conn = self.db.get_conn()?;
 

--- a/server/src/repositories/traits/fund_round_repo.rs
+++ b/server/src/repositories/traits/fund_round_repo.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 use crate::data::error::DbError;
 use crate::models::group::group_wallet::GroupWallet;
 use crate::models::proposal::NewProposal;
-use crate::models::proposals::fund_round::FundProposalExpanded;
+use crate::models::proposals::fund_round::{FundProposal, FundProposalExpanded};
 use crate::models::transaction::fund_round_contrib::FundRoundContribution;
 
 pub trait FundRoundRepository: Send + Sync {
@@ -17,6 +17,11 @@ pub trait FundRoundRepository: Send + Sync {
 
     fn find_fund_round(&self, fund_round_id: Uuid)
     -> Result<Option<FundProposalExpanded>, DbError>;
+
+    fn get_all_fund_round_proposals(
+        &self,
+        group_id: Uuid,
+    ) -> Result<Vec<FundProposalExpanded>, DbError>;
 
     fn get_total_contributed(&self, fund_round_id: Uuid) -> Result<BigDecimal, DbError>;
 

--- a/server/src/repositories/traits/fund_round_repo.rs
+++ b/server/src/repositories/traits/fund_round_repo.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 use crate::data::error::DbError;
 use crate::models::group::group_wallet::GroupWallet;
 use crate::models::proposal::NewProposal;
-use crate::models::proposals::fund_round::{FundProposal, FundProposalExpanded};
+use crate::models::proposals::fund_round::FundProposalExpanded;
 use crate::models::transaction::fund_round_contrib::FundRoundContribution;
 
 pub trait FundRoundRepository: Send + Sync {
@@ -45,4 +45,6 @@ pub trait FundRoundRepository: Send + Sync {
         user_id: Uuid,
         fund_round_id: Uuid,
     ) -> Result<BigDecimal, DbError>;
+
+    fn count_contributors(&self, fund_round_id: Uuid) -> Result<i64, DbError>;
 }

--- a/server/src/routes/group_wallet.rs
+++ b/server/src/routes/group_wallet.rs
@@ -1,7 +1,8 @@
 use crate::data::state::SharedState;
 use crate::handlers::group_wallet::{
     cancel_fund_round, contribute_fund_round, create_fund_round, create_group_wallet,
-    get_all_fund_rounds, get_fund_round, get_group_wallets, get_user_contrib,
+    get_all_fund_rounds, get_fund_round, get_fund_round_remaining, get_group_wallets,
+    get_user_contrib,
 };
 use crate::security::middlewares::auth::auth_middleware;
 use crate::security::middlewares::is_in_group::{
@@ -51,6 +52,11 @@ pub fn group_wallet_routes(state: SharedState) -> Router {
         )
         // Find fund round
         .route("/fund-round/{fund_round_id}", get(get_fund_round))
+        // Exact remaining amount to complete the fund round
+        .route(
+            "/fund-round/{fund_round_id}/remaining",
+            get(get_fund_round_remaining),
+        )
         // Cancel fund round
         .route(
             "/fund-round/{fund_round_id}/cancel",

--- a/server/src/routes/group_wallet.rs
+++ b/server/src/routes/group_wallet.rs
@@ -1,7 +1,7 @@
 use crate::data::state::SharedState;
 use crate::handlers::group_wallet::{
     cancel_fund_round, contribute_fund_round, create_fund_round, create_group_wallet,
-    get_fund_round, get_group_wallets, get_user_contrib,
+    get_all_fund_rounds, get_fund_round, get_group_wallets, get_user_contrib,
 };
 use crate::security::middlewares::auth::auth_middleware;
 use crate::security::middlewares::is_in_group::{
@@ -41,6 +41,13 @@ pub fn group_wallet_routes(state: SharedState) -> Router {
         .route(
             "/fund-round/{fund_round_id}/contribute",
             post(contribute_fund_round).get(get_user_contrib),
+        )
+        .route(
+            "/fund-round/{group_id}/get-all",
+            get(get_all_fund_rounds).route_layer(middleware::from_fn_with_state(
+                state.clone(),
+                is_in_group_middleware,
+            )),
         )
         // Find fund round
         .route("/fund-round/{fund_round_id}", get(get_fund_round))

--- a/server/src/services/group.rs
+++ b/server/src/services/group.rs
@@ -107,7 +107,7 @@ impl GroupService {
 
             if !has_other_admin {
                 return Err(AppError::BadRequest(
-                    "Group must have at least one other admin".into(),
+                    "El grupo tiene que tener al menos un admin".into(),
                 ));
             }
         }

--- a/server/src/services/group_wallet.rs
+++ b/server/src/services/group_wallet.rs
@@ -348,6 +348,15 @@ impl GroupWalletService {
             .ok_or(AppError::NotFound)
     }
 
+    pub fn get_all_fund_rounds(
+        &self,
+        group_id: Uuid,
+    ) -> Result<Vec<FundProposalExpanded>, AppError> {
+        self.fund_round_repo
+            .get_all_fund_round_proposals(group_id)
+            .map_err(AppError::Db)
+    }
+
     fn find_total_contribution(&self, fund_round_id: Uuid) -> Result<BigDecimal, AppError> {
         self.fund_round_repo
             .get_total_contributed(fund_round_id)

--- a/server/src/services/group_wallet.rs
+++ b/server/src/services/group_wallet.rs
@@ -258,6 +258,46 @@ impl GroupWalletService {
         })
     }
 
+    // Devuelve el monto EXACTO que falta para completar la ronda (target - total_contribuido)
+    // junto con un flag que indica si el usuario es el ÚLTIMO miembro del grupo que aún no
+    // aportó. Si es el último, el cliente debe mandar este remaining exacto para cerrar la
+    // ronda sin dejar centavos colgados por errores de redondeo previos.
+    pub fn get_fund_round_remaining(
+        &self,
+        user_id: Uuid,
+        fund_round_id: Uuid,
+    ) -> Result<(BigDecimal, bool), AppError> {
+        let fund_round = self.find_fund_round(fund_round_id)?;
+        let group_id = fund_round.proposal.group_id;
+        self.validate_is_member(user_id, group_id)?;
+
+        let total_contributed = self.find_total_contribution(fund_round_id)?;
+        let target = fund_round.fund_round_proposal.target_amount.clone();
+
+        let remaining = &target - &total_contributed;
+
+        if remaining < BigDecimal::zero() {
+            return Err(AppError::BadRequest(
+                "Fund round is not active, insufficient funds, or amount exceeds remaining target"
+                    .into(),
+            ));
+        }
+
+        // Regla: el que llama es el "último" aportante si aún no aportó y queda exactamente
+        // un miembro sin aportar (él). Así sabemos que tiene que cubrir todo lo que falta.
+        let total_members = self.group_repo.get_group_members(group_id)?.len() as i64;
+        let contributors = self.fund_round_repo.count_contributors(fund_round_id)?;
+        let has_contributed = self
+            .fund_round_repo
+            .find_user_contrib(fund_round_id, user_id)?
+            .is_some();
+
+        let pending_members = total_members - contributors;
+        let is_last_contributor = !has_contributed && pending_members == 1;
+
+        Ok((remaining, is_last_contributor))
+    }
+
     pub fn cancel_fund_round(
         &self,
         user_id: Uuid,
@@ -269,7 +309,10 @@ impl GroupWalletService {
             return Err(AppError::BadRequest("Fund round is not active".into()));
         }
 
-        self.validate_is_admin(user_id, fund_round.proposal.group_id)?;
+        // Only the creator of the fund round can cancel it.
+        if fund_round.proposal.created_by != user_id {
+            return Err(AppError::Forbidden);
+        }
 
         self.proposal_repo
             .update_proposal_status(


### PR DESCRIPTION
This pull request introduces the core backend and frontend support for group fund rounds, including API endpoints, business logic, and type definitions. The main features are the ability to create and manage fund rounds within a group, track contributions, and handle the exact completion of a funding goal. The changes span new API endpoints, repository and service logic, type definitions, and a new modal component for creating fund rounds.

**Backend API and Logic Enhancements**

* Added endpoints and handler logic to:
  - Create, cancel, and get the status of fund rounds (`create_fund_round`, `cancel_fund_round`, `get_fund_round`) [[1]](diffhunk://#diff-6affb4ea1202a122d75f25b353db2b0c7927e5786fe3f0b6356260287af3afcaR32-R40) [[2]](diffhunk://#diff-6affb4ea1202a122d75f25b353db2b0c7927e5786fe3f0b6356260287af3afcaR99-R113) [[3]](diffhunk://#diff-81fbd1f7695eaf1a9137f83b68eb5f0232499a7921cc4a6f697f8b89029f030fL4-R5) [[4]](diffhunk://#diff-81fbd1f7695eaf1a9137f83b68eb5f0232499a7921cc4a6f697f8b89029f030fR46-R59)
  - Retrieve all fund rounds for a group (`get_all_fund_rounds`) [[1]](diffhunk://#diff-6affb4ea1202a122d75f25b353db2b0c7927e5786fe3f0b6356260287af3afcaR138-R144) [[2]](diffhunk://#diff-81fbd1f7695eaf1a9137f83b68eb5f0232499a7921cc4a6f697f8b89029f030fL4-R5) [[3]](diffhunk://#diff-81fbd1f7695eaf1a9137f83b68eb5f0232499a7921cc4a6f697f8b89029f030fR46-R59)
  - Get the exact remaining amount to complete a fund round, including a flag for the last contributor (`get_fund_round_remaining`) [[1]](diffhunk://#diff-6affb4ea1202a122d75f25b353db2b0c7927e5786fe3f0b6356260287af3afcaR99-R113) [[2]](diffhunk://#diff-81fbd1f7695eaf1a9137f83b68eb5f0232499a7921cc4a6f697f8b89029f030fL4-R5) [[3]](diffhunk://#diff-81fbd1f7695eaf1a9137f83b68eb5f0232499a7921cc4a6f697f8b89029f030fR46-R59) [[4]](diffhunk://#diff-6c906f7090616fccc8166197258433ad3e66770d3e73f866d712a0eadb5c4ecbR261-R300)
* Enforced that only the fund round creator can cancel a fund round

**Repository and Service Layer Updates**

* Implemented repository methods for:
  - Fetching all fund round proposals for a group (`get_all_fund_round_proposals`) [[1]](diffhunk://#diff-11daa66409133dd4626c686841440ae4e4bc64da3544a3ee4fd5222a69da5efeR102-R122) [[2]](diffhunk://#diff-8eb4b539626439c32a69dd2aaccbdbb41f4b7071e9d0b9129a038e26e2d4d57dR21-R25)
  - Counting contributors to a fund round, used to determine the last contributor (`count_contributors`) [[1]](diffhunk://#diff-11daa66409133dd4626c686841440ae4e4bc64da3544a3ee4fd5222a69da5efeR289-R302) [[2]](diffhunk://#diff-8eb4b539626439c32a69dd2aaccbdbb41f4b7071e9d0b9129a038e26e2d4d57dR48-R49)
* Service logic to calculate the exact remaining amount and determine if the user is the last contributor

**Frontend Integration**

* Added a new modal component `CreateFundRound.svelte` for proposing a new fund round, including form validation and integration with the new API endpoints
* Created a new API module `fund_rounds.ts` with functions to interact with the backend endpoints

**Type Definitions and Utilities**

* Defined new TypeScript types for fund rounds, contributions, and API responses in `fund_rounds.types.ts`
* Added a utility to map proposal statuses to display labels and styles (`getProposalStatusDisplay`)
* Exported `ProposalStatus` type for use across modules

**Other Improvements**

* Improved error messages for group admin requirements

These changes collectively enable the creation, management, and completion of group fund rounds, providing both backend infrastructure and frontend user flows.