### PR TITLE
MiniFeature: Vista de usuario

### DIFF
--- a/client/src/routes/dashboard/+page.svelte
+++ b/client/src/routes/dashboard/+page.svelte
@@ -14,6 +14,7 @@
 	let error = $state('');
 	let misGrupos = $state<GroupSummary[]>([]);
 	let showNewGroup = $state(false);
+	let didInitializeStatusFilter = $state(false);
 
 	let filterRole = $state<'all' | 'Admin' | 'Member'>('all');
 	let filterStatus = $state<'all' | 'Active' | 'Ended'>('Active');
@@ -41,6 +42,11 @@
 		}
 
 		misGrupos = res.body;
+		if (!didInitializeStatusFilter) {
+			const hasActiveGroups = misGrupos.some((group) => group.status.toLowerCase() === 'active');
+			filterStatus = hasActiveGroups ? 'Active' : 'all';
+			didInitializeStatusFilter = true;
+		}
 		isLoading = false;
 	}
 
@@ -73,7 +79,7 @@
 			<div class="flex items-center gap-2">
 				<span class="text-xs font-medium text-gray-500">Rol</span>
 				<div class="flex gap-1">
-					{#each [['all', 'Todos'], ['Admin', 'Admin'], ['Member', 'Miembro']] as [val, label]}
+					{#each [['all', 'Todos'], ['Admin', 'Admin'], ['Member', 'Miembro']] as [val, label] (val)}
 						<button
 							onclick={() => (filterRole = val as typeof filterRole)}
 							class={filterRole === val
@@ -89,7 +95,7 @@
 			<div class="flex items-center gap-2">
 				<span class="text-xs font-medium text-gray-500">Estado</span>
 				<div class="flex gap-1">
-					{#each [{ val: 'all', label: 'Todos', dot: '', active: 'bg-black text-white border-transparent', inactive: 'border-gray-200 text-gray-500 hover:bg-gray-100 hover:border-gray-400 hover:text-black' }, { val: 'Active', label: 'Activo', dot: 'bg-green-500', active: 'text-green-800 bg-green-200 border-green-600', inactive: 'border-green-200 text-green-600 hover:bg-green-100 hover:border-green-400 hover:text-green-800' }, { val: 'Ended', label: 'Finalizado', dot: 'bg-red-400', active: 'bg-red-200 border-red-400 text-red-700', inactive: 'border-red-200 text-red-400 hover:bg-red-100 hover:border-red-400 hover:text-red-700' }] as opt}
+					{#each [{ val: 'all', label: 'Todos', dot: '', active: 'bg-black text-white border-transparent', inactive: 'border-gray-200 text-gray-500 hover:bg-gray-100 hover:border-gray-400 hover:text-black' }, { val: 'Active', label: 'Activo', dot: 'bg-green-500', active: 'text-green-800 bg-green-200 border-green-600', inactive: 'border-green-200 text-green-600 hover:bg-green-100 hover:border-green-400 hover:text-green-800' }, { val: 'Ended', label: 'Finalizado', dot: 'bg-red-400', active: 'bg-red-200 border-red-400 text-red-700', inactive: 'border-red-200 text-red-400 hover:bg-red-100 hover:border-red-400 hover:text-red-700' }] as opt (opt.val)}
 						<button
 							onclick={() => (filterStatus = opt.val as typeof filterStatus)}
 							class="flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition {filterStatus ===

--- a/client/src/routes/profile/me/+page.svelte
+++ b/client/src/routes/profile/me/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Copy, Plus, Send, ArrowDownToLine, Wallet } from 'lucide-svelte';
+	import { ArrowLeft, ArrowDownToLine, Copy, Plus, Send, Wallet } from 'lucide-svelte';
 	import type { User } from '$lib/types/endpoints/auth.types';
 	import { me } from '$lib/api/auth';
 	import { type FailedResponse, isSuccess, type SuccessResponse } from '$lib/types/client.types';
@@ -50,6 +50,14 @@
 		// Acá podrías disparar un toast de "Copiado!"
 	}
 
+	function goBack() {
+		if (typeof history !== 'undefined' && history.length > 1) {
+			history.back();
+		} else {
+			window.location.href = '/dashboard';
+		}
+	}
+
 	loadUserProfile();
 	loadWallets();
 </script>
@@ -59,6 +67,14 @@
 </svelte:head>
 
 <div class="mx-auto flex w-full max-w-2xl flex-col gap-8 p-6 pt-8">
+	<button
+		onclick={goBack}
+		class="flex w-fit items-center gap-2 rounded-full border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-600 transition hover:border-gray-400 hover:text-black"
+	>
+		<ArrowLeft class="h-3.5 w-3.5" />
+		Volver
+	</button>
+
 	<div class="flex items-center gap-4 rounded-xl border border-gray-200 bg-white p-6">
 		<div class="flex flex-col">
 			<h1 class="text-2xl font-bold text-black">{user.name}</h1>

--- a/client/src/routes/users/[user_id]/+page.svelte
+++ b/client/src/routes/users/[user_id]/+page.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
 	import { apiFetch } from '$lib/api/client';
+	import { authStore } from '$lib/stores/auth';
 	import { ArrowLeft, Mail, User as UserIcon } from 'lucide-svelte';
 
 	type UserSummary = {
@@ -38,6 +40,12 @@
 		if (!userId) {
 			error = 'No se encontro el id del usuario.';
 			isLoading = false;
+			return;
+		}
+
+		const currentUserId = $authStore.user?.id;
+		if (currentUserId && userId === currentUserId) {
+			await goto('/profile/me', { replaceState: true });
 			return;
 		}
 

--- a/client/src/routes/users/[user_id]/+page.svelte
+++ b/client/src/routes/users/[user_id]/+page.svelte
@@ -1,0 +1,133 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { onMount } from 'svelte';
+	import { apiFetch } from '$lib/api/client';
+	import { ArrowLeft, Mail, User as UserIcon } from 'lucide-svelte';
+
+	type UserSummary = {
+		id: string;
+		name: string;
+		email: string;
+	};
+
+	const userId = $derived(page.params.user_id);
+
+	let isLoading = $state(true);
+	let error = $state('');
+	let user = $state<UserSummary | null>(null);
+
+	const initials = $derived(
+		(user?.name ?? '')
+			.trim()
+			.split(/\s+/)
+			.filter(Boolean)
+			.slice(0, 2)
+			.map((part) => part[0]?.toUpperCase() ?? '')
+			.join('') || '?'
+	);
+
+	function goBack() {
+		if (typeof history !== 'undefined' && history.length > 1) {
+			history.back();
+		} else {
+			window.location.href = '/dashboard';
+		}
+	}
+
+	onMount(async () => {
+		if (!userId) {
+			error = 'No se encontro el id del usuario.';
+			isLoading = false;
+			return;
+		}
+
+		const response = await apiFetch<UserSummary>(`/users/${userId}`);
+
+		if (!response.ok) {
+			error = response.message || 'No se pudo cargar el usuario.';
+			isLoading = false;
+			return;
+		}
+
+		user = response.body;
+		isLoading = false;
+	});
+</script>
+
+<svelte:head>
+	<title>Lemipay - Perfil</title>
+</svelte:head>
+
+<div class="mx-auto flex w-full max-w-2xl flex-col gap-6 p-6 pt-8">
+	<button
+		onclick={goBack}
+		class="flex w-fit items-center gap-2 rounded-full border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-600 transition hover:border-gray-400 hover:text-black"
+	>
+		<ArrowLeft class="h-3.5 w-3.5" />
+		Volver
+	</button>
+
+	<h1 class="text-xl font-bold text-black">Perfil de usuario</h1>
+
+	{#if isLoading}
+		<div class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+			<div class="flex items-center gap-4">
+				<div class="h-16 w-16 animate-pulse rounded-full bg-gray-200"></div>
+				<div class="flex flex-1 flex-col gap-2">
+					<div class="h-4 w-1/2 animate-pulse rounded bg-gray-200"></div>
+					<div class="h-3 w-2/3 animate-pulse rounded bg-gray-200"></div>
+				</div>
+			</div>
+		</div>
+	{:else if error}
+		<div class="rounded-lg border border-red-300 bg-red-50 p-4 text-red-700">
+			<p class="font-medium">Hubo un problema al cargar el usuario.</p>
+			<p class="text-sm">{error}</p>
+		</div>
+	{:else if user}
+		<div class="flex flex-col gap-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+			<div class="flex items-center gap-4">
+				<div
+					class="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-linear-to-br from-gray-200 to-gray-300 text-lg font-semibold text-gray-700 select-none"
+					aria-hidden="true"
+				>
+					{initials}
+				</div>
+				<div class="min-w-0">
+					<p class="truncate text-lg font-semibold text-black">{user.name}</p>
+					<p class="truncate text-sm text-gray-500">{user.email}</p>
+				</div>
+			</div>
+
+			<div class="h-px w-full bg-gray-100"></div>
+
+			<dl class="flex flex-col gap-4 text-sm">
+				<div class="flex items-start gap-3">
+					<UserIcon class="mt-0.5 h-4 w-4 text-gray-400" />
+					<div class="flex flex-col">
+						<dt class="text-xs font-medium text-gray-500">Nombre</dt>
+						<dd class="text-sm text-black">{user.name}</dd>
+					</div>
+				</div>
+
+				<div class="flex items-start gap-3">
+					<Mail class="mt-0.5 h-4 w-4 text-gray-400" />
+					<div class="flex flex-col">
+						<dt class="text-xs font-medium text-gray-500">Email</dt>
+						<dd class="text-sm text-black">{user.email}</dd>
+					</div>
+				</div>
+
+				<div class="flex items-start gap-3">
+					<span class="mt-0.5 text-xs font-semibold text-gray-400">ID</span>
+					<div class="flex flex-col">
+						<dt class="text-xs font-medium text-gray-500">Identificador</dt>
+						<dd class="font-mono text-xs break-all text-gray-700">{user.id}</dd>
+					</div>
+				</div>
+			</dl>
+		</div>
+	{:else}
+		<p class="text-sm text-gray-500">No hay informacion disponible para este usuario.</p>
+	{/if}
+</div>


### PR DESCRIPTION
This pull request introduces a new user profile page and makes improvements to the dashboard's group filtering logic and UI. The main changes are the addition of the user profile view and enhancements to the filtering experience in the dashboard.

**New Feature: User Profile Page**

* Added a new `+page.svelte` under `client/src/routes/users/[user_id]/` to display user profile information. This page fetches the user data based on the `user_id` route parameter, shows loading and error states, and displays the user's initials, name, email, and ID with a back navigation button. ([client/src/routes/users/[user_id]/+page.svelteR1-R133](diffhunk://#diff-90ec5c7c386d2354eed3b3f492274ba439eb2eb83cf228243722813a2622714dR1-R133))

**Dashboard Filtering Improvements**

* Improved the initialization of the status filter in the dashboard: now, if there are no active groups, the filter defaults to `'all'` instead of `'Active'`. This prevents empty results when a user has no active groups. [[1]](diffhunk://#diff-88c5b4da37069884a073e7ec61383843b65080013ab8248a816775cb5096ac15R17) [[2]](diffhunk://#diff-88c5b4da37069884a073e7ec61383843b65080013ab8248a816775cb5096ac15R45-R49)
* Enhanced the reactivity and performance of role and status filter button rendering by adding keyed `{#each ... (key)}` blocks in the dashboard filter UI. [[1]](diffhunk://#diff-88c5b4da37069884a073e7ec61383843b65080013ab8248a816775cb5096ac15L76-R82) [[2]](diffhunk://#diff-88c5b4da37069884a073e7ec61383843b65080013ab8248a816775cb5096ac15L92-R98)