### PR TITLE
Feature: exponer core en api

### DIFF
--- a/server/src/data/state.rs
+++ b/server/src/data/state.rs
@@ -1,4 +1,5 @@
 use crate::services::auth::AuthService;
+use crate::services::core::CoreService;
 use crate::services::group::GroupService;
 use crate::services::group_wallet::GroupWalletService;
 use crate::services::proposal::ProposalService;
@@ -19,6 +20,7 @@ pub struct AppState {
     pub transaction_service: TransactionService,
     pub user_wallet_service: UserWalletService,
     pub group_wallet_service: GroupWalletService,
+    pub core_service: CoreService,
 }
 
 pub type SharedState = Arc<AppState>;

--- a/server/src/errors/app_error.rs
+++ b/server/src/errors/app_error.rs
@@ -31,6 +31,9 @@ pub enum AppError {
 
     #[error("Forbidden")]
     Forbidden,
+
+    #[error("Core")]
+    Core,
 }
 
 #[derive(Serialize)]
@@ -48,6 +51,7 @@ impl IntoResponse for AppError {
             AppError::PasswordHash(err) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
             AppError::Unauthorized => (StatusCode::UNAUTHORIZED, self.to_string()),
             AppError::Forbidden => (StatusCode::FORBIDDEN, self.to_string()),
+            AppError::Core => (StatusCode::CONFLICT, self.to_string()),
         };
 
         let body = Json(ErrorResponse { message });

--- a/server/src/errors/app_error.rs
+++ b/server/src/errors/app_error.rs
@@ -32,7 +32,7 @@ pub enum AppError {
     #[error("Forbidden")]
     Forbidden,
 
-    #[error("Core")]
+    #[error("Core operation failed")]
     Core,
 }
 

--- a/server/src/handlers/core.rs
+++ b/server/src/handlers/core.rs
@@ -13,6 +13,7 @@ use uuid::Uuid;
 
 #[derive(Serialize)]
 pub struct UserBalance {
+    pub user_name: String,
     pub user_id: Uuid,
     pub balance: BigDecimal,
 }
@@ -27,7 +28,7 @@ pub async fn get_balances(
     State(state): State<SharedState>,
     Path(group_id): Path<Uuid>,
     user: AuthUser,
-) -> Result<Json<Vec<Balances>>, AppError> {
-    let result;
+) -> Result<Json<Balances>, AppError> {
+    let result = state.core_service.get_balances(group_id)?;
     Ok(Json(result))
 }

--- a/server/src/handlers/core.rs
+++ b/server/src/handlers/core.rs
@@ -4,7 +4,7 @@ use crate::security::auth_extractor::AuthUser;
 
 use axum::{
     Json,
-    extract::{Path, Query, State},
+    extract::{Path, State},
 };
 
 use bigdecimal::BigDecimal;

--- a/server/src/handlers/core.rs
+++ b/server/src/handlers/core.rs
@@ -1,0 +1,33 @@
+use crate::data::state::SharedState;
+use crate::errors::app_error::AppError;
+use crate::security::auth_extractor::AuthUser;
+
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+};
+
+use bigdecimal::BigDecimal;
+use serde::Serialize;
+use uuid::Uuid;
+
+#[derive(Serialize)]
+pub struct UserBalance {
+    pub user_id: Uuid,
+    pub balance: BigDecimal,
+}
+
+#[derive(Serialize)]
+pub struct Balances {
+    pub group_balance: BigDecimal,
+    pub balances: Vec<UserBalance>,
+}
+
+pub async fn get_balances(
+    State(state): State<SharedState>,
+    Path(group_id): Path<Uuid>,
+    user: AuthUser,
+) -> Result<Json<Vec<Balances>>, AppError> {
+    let result;
+    Ok(Json(result))
+}

--- a/server/src/handlers/core.rs
+++ b/server/src/handlers/core.rs
@@ -27,7 +27,7 @@ pub struct Balances {
 pub async fn get_balances(
     State(state): State<SharedState>,
     Path(group_id): Path<Uuid>,
-    user: AuthUser,
+    _user: AuthUser,
 ) -> Result<Json<Balances>, AppError> {
     let result = state.core_service.get_balances(group_id)?;
     Ok(Json(result))

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod core;
 pub mod group;
 pub mod group_wallet;
 pub mod proposal;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -77,6 +77,7 @@ async fn main() {
         proposal_repo.clone(),
         user_wallet_repo.clone(),
     );
+    let core_service = 
     let state = Arc::new(AppState {
         user_service,
         auth_service,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -81,7 +81,11 @@ async fn main() {
         proposal_repo.clone(),
         user_wallet_repo.clone(),
     );
-    let core_service = CoreService::new(transaction_repo.clone());
+    let core_service = CoreService::new(
+        transaction_repo.clone(),
+        group_repo.clone(),
+        expense_repo.clone(),
+    );
     let expense_service = ExpenseService::new(expense_repo.clone());
     let state = Arc::new(AppState {
         user_service,

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -33,6 +33,7 @@ use crate::repositories::diesel::user_wallet_repo_impl::DieselUserWalletReposito
 
 // Services
 use crate::services::auth::AuthService;
+use crate::services::core::CoreService;
 use crate::services::group::GroupService;
 use crate::services::group_wallet::GroupWalletService;
 use crate::services::proposal::ProposalService;
@@ -77,7 +78,7 @@ async fn main() {
         proposal_repo.clone(),
         user_wallet_repo.clone(),
     );
-    let core_service = 
+    let core_service = CoreService::new(transaction_repo.clone());
     let state = Arc::new(AppState {
         user_service,
         auth_service,
@@ -86,6 +87,7 @@ async fn main() {
         transaction_service,
         user_wallet_service,
         group_wallet_service,
+        core_service,
     });
 
     // 🚏 Router

--- a/server/src/repositories/diesel/group_repo_impl.rs
+++ b/server/src/repositories/diesel/group_repo_impl.rs
@@ -123,6 +123,28 @@ impl GroupRepository for DieselGroupRepository {
         Ok(result.is_some())
     }
 
+    fn get_historic_group_members(&self, group_id: Uuid) -> Result<Vec<GroupMember>, DbError> {
+        let mut conn = self.db.get_conn()?;
+        let raw_result = user_in_group::table
+            .inner_join(user::table)
+            .filter(user_in_group::group_id.eq(group_id))
+            .get_results::<(UserInGroup, User)>(&mut conn)?;
+
+        let members = raw_result
+            .into_iter()
+            .map(|(rel, u)| GroupMember {
+                user_id: u.id,
+                group_id: rel.group_id,
+                name: u.name,
+                email: u.email,
+                status: rel.status,
+                role: rel.role,
+            })
+            .collect();
+
+        Ok(members)
+    }
+
     fn get_group_members(&self, group_id: Uuid) -> Result<Vec<GroupMember>, DbError> {
         let mut conn = self.db.get_conn()?;
         let raw_result = user_in_group::table

--- a/server/src/repositories/traits/group_repo.rs
+++ b/server/src/repositories/traits/group_repo.rs
@@ -17,6 +17,7 @@ pub trait GroupRepository: Send + Sync {
     -> Result<UserInGroup, DbError>;
     fn delete_group(&self, group_id: Uuid) -> Result<Group, DbError>;
     fn is_group_active(&self, group_id: Uuid) -> Result<bool, DbError>;
+    fn get_historic_group_members(&self, group_id: Uuid) -> Result<Vec<GroupMember>, DbError>;
     fn get_group_members(&self, group_id: Uuid) -> Result<Vec<GroupMember>, DbError>;
     fn get_user_groups(&self, user_id: Uuid) -> Result<Vec<GroupFromUser>, DbError>;
     fn update_group_info(

--- a/server/src/router.rs
+++ b/server/src/router.rs
@@ -9,6 +9,7 @@ use tower_http::cors::CorsLayer;
 
 // Routes
 use crate::routes::auth::auth_routes;
+use crate::routes::core::core_routes;
 use crate::routes::expense::expense_routes;
 use crate::routes::group::group_routes;
 use crate::routes::group_wallet::group_wallet_routes;
@@ -35,5 +36,6 @@ pub fn create_router(state: SharedState) -> Router {
         .nest("/wallet", user_wallet_routes(state.clone()))
         .nest("/group-wallet", group_wallet_routes(state.clone()))
         .nest("/expense", expense_routes(state.clone()))
+        .nest("/core", core_routes(state.clone()))
         .layer(cors) //este layer tiene que ir al final de la creación del Router por si dsp hay que agregar otros nest
 }

--- a/server/src/routes/core.rs
+++ b/server/src/routes/core.rs
@@ -1,0 +1,18 @@
+use axum::routing::{get, post};
+use axum::{Router, middleware};
+
+use crate::data::state::SharedState;
+use crate::handlers::core::get_balances;
+use crate::security::middlewares::auth::auth_middleware;
+use crate::security::middlewares::is_in_group::is_in_group_middleware;
+
+pub fn core_routes(state: SharedState) -> Router {
+    Router::new()
+        .route("/balances", get(get_balances))
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            is_in_group_middleware,
+        ))
+        .route_layer(middleware::from_fn(auth_middleware))
+        .with_state(state)
+}

--- a/server/src/routes/core.rs
+++ b/server/src/routes/core.rs
@@ -1,4 +1,4 @@
-use axum::routing::{get, post};
+use axum::routing::get;
 use axum::{Router, middleware};
 
 use crate::data::state::SharedState;

--- a/server/src/routes/core.rs
+++ b/server/src/routes/core.rs
@@ -8,7 +8,7 @@ use crate::security::middlewares::is_in_group::is_in_group_middleware;
 
 pub fn core_routes(state: SharedState) -> Router {
     Router::new()
-        .route("/balances", get(get_balances))
+        .route("/balances/{group_id}", get(get_balances))
         .route_layer(middleware::from_fn_with_state(
             state.clone(),
             is_in_group_middleware,

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod core;
 pub mod group;
 pub mod group_wallet;
 pub mod proposal;

--- a/server/src/services/core.rs
+++ b/server/src/services/core.rs
@@ -41,7 +41,10 @@ impl CoreService {
         let expenses = self.expense_repo.find_by_group(group_id)?;
 
         //call core
-        let result = core(users_ids, transactions, expenses).map_err(|_| AppError::Core)?;
+        let result = core(users_ids, transactions, expenses).map_err(|err| {
+            eprintln!("core(users_ids, transactions, expenses) failed for group {group_id}: {err:?}");
+            AppError::Core
+        })?;
 
         //map core pretty
         let balances = historic_members

--- a/server/src/services/core.rs
+++ b/server/src/services/core.rs
@@ -1,22 +1,60 @@
+use crate::core::core::core;
 use std::sync::Arc;
 use uuid::Uuid;
 
-use bigdecimal::BigDecimal;
+use bigdecimal::{BigDecimal, Zero};
 
 use crate::errors::app_error::AppError;
-use crate::handlers::core::Balances;
+use crate::handlers::core::{Balances, UserBalance};
+use crate::models::expense::Expense;
+use crate::repositories::traits::group_repo::GroupRepository;
 use crate::repositories::traits::transaction_repo::TransactionRepository;
 
 #[derive(Clone)]
 pub struct CoreService {
     transaction_repo: Arc<dyn TransactionRepository>,
+    group_repo: Arc<dyn GroupRepository>,
 }
 impl CoreService {
-    pub fn new(transaction_repo: Arc<dyn TransactionRepository>) -> Self {
-        Self { transaction_repo }
+    pub fn new(
+        transaction_repo: Arc<dyn TransactionRepository>,
+        group_repo: Arc<dyn GroupRepository>,
+    ) -> Self {
+        Self {
+            transaction_repo,
+            group_repo,
+        }
     }
 
     pub fn get_balances(&self, group_id: Uuid) -> Result<Balances, AppError> {
+        //get all users historically
+        let historic_members = self.group_repo.get_historic_group_members(group_id)?;
+        let users_ids = historic_members.iter().map(|m| m.user_id).collect();
 
+        //get all transactions
+        let transactions = self.transaction_repo.find_by_group(group_id)?;
+
+        //get all expenses
+        let expenses = vec![] as Vec<Expense>;
+
+        //call core
+        let result = core(users_ids, transactions, expenses).map_err(|_| AppError::Core)?;
+
+        let balances = historic_members
+            .iter()
+            .map(|member| UserBalance {
+                user_id: member.user_id,
+                user_name: member.name.clone(),
+                balance: result
+                    .get_user_balance(&member.user_id)
+                    .cloned()
+                    .unwrap_or(BigDecimal::zero()),
+            })
+            .collect();
+
+        Ok(Balances {
+            group_balance: result.get_group_balance().clone(),
+            balances,
+        })
     }
 }

--- a/server/src/services/core.rs
+++ b/server/src/services/core.rs
@@ -1,0 +1,22 @@
+use std::sync::Arc;
+use uuid::Uuid;
+
+use bigdecimal::BigDecimal;
+
+use crate::errors::app_error::AppError;
+use crate::handlers::core::Balances;
+use crate::repositories::traits::transaction_repo::TransactionRepository;
+
+#[derive(Clone)]
+pub struct CoreService {
+    transaction_repo: Arc<dyn TransactionRepository>,
+}
+impl CoreService {
+    pub fn new(transaction_repo: Arc<dyn TransactionRepository>) -> Self {
+        Self { transaction_repo }
+    }
+
+    pub fn get_balances(&self, group_id: Uuid) -> Result<Balances, AppError> {
+
+    }
+}

--- a/server/src/services/core.rs
+++ b/server/src/services/core.rs
@@ -41,10 +41,7 @@ impl CoreService {
         let expenses = self.expense_repo.find_by_group(group_id)?;
 
         //call core
-        let result = core(users_ids, transactions, expenses).map_err(|err| {
-            eprintln!("core(users_ids, transactions, expenses) failed for group {group_id}: {err:?}");
-            AppError::Core
-        })?;
+        let result = core(users_ids, transactions, expenses).map_err(|_| AppError::Core)?;
 
         //map core pretty
         let balances = historic_members

--- a/server/src/services/core.rs
+++ b/server/src/services/core.rs
@@ -7,6 +7,7 @@ use bigdecimal::{BigDecimal, Zero};
 use crate::errors::app_error::AppError;
 use crate::handlers::core::{Balances, UserBalance};
 use crate::models::expense::Expense;
+use crate::repositories::traits::expense_repo::ExpenseRepository;
 use crate::repositories::traits::group_repo::GroupRepository;
 use crate::repositories::traits::transaction_repo::TransactionRepository;
 
@@ -14,15 +15,18 @@ use crate::repositories::traits::transaction_repo::TransactionRepository;
 pub struct CoreService {
     transaction_repo: Arc<dyn TransactionRepository>,
     group_repo: Arc<dyn GroupRepository>,
+    expense_repo: Arc<dyn ExpenseRepository>,
 }
 impl CoreService {
     pub fn new(
         transaction_repo: Arc<dyn TransactionRepository>,
         group_repo: Arc<dyn GroupRepository>,
+        expense_repo: Arc<dyn ExpenseRepository>,
     ) -> Self {
         Self {
             transaction_repo,
             group_repo,
+            expense_repo,
         }
     }
 
@@ -35,11 +39,12 @@ impl CoreService {
         let transactions = self.transaction_repo.find_by_group(group_id)?;
 
         //get all expenses
-        let expenses = vec![] as Vec<Expense>;
+        let expenses = self.expense_repo.find_by_group(group_id)?;
 
         //call core
         let result = core(users_ids, transactions, expenses).map_err(|_| AppError::Core)?;
 
+        //map core pretty
         let balances = historic_members
             .iter()
             .map(|member| UserBalance {

--- a/server/src/services/core.rs
+++ b/server/src/services/core.rs
@@ -6,7 +6,6 @@ use bigdecimal::{BigDecimal, Zero};
 
 use crate::errors::app_error::AppError;
 use crate::handlers::core::{Balances, UserBalance};
-use crate::models::expense::Expense;
 use crate::repositories::traits::expense_repo::ExpenseRepository;
 use crate::repositories::traits::group_repo::GroupRepository;
 use crate::repositories::traits::transaction_repo::TransactionRepository;

--- a/server/src/services/mod.rs
+++ b/server/src/services/mod.rs
@@ -1,8 +1,8 @@
 pub mod auth;
+pub mod core;
 pub mod group;
 pub mod group_wallet;
 pub mod proposal;
 pub mod transaction;
 pub mod user;
 pub mod user_wallet;
-mod core;

--- a/server/src/services/mod.rs
+++ b/server/src/services/mod.rs
@@ -5,3 +5,4 @@ pub mod proposal;
 pub mod transaction;
 pub mod user;
 pub mod user_wallet;
+mod core;


### PR DESCRIPTION
This pull request introduces a new "core" module to the backend, enabling retrieval of group balances and per-user balances within a group. It adds a new API endpoint for group balance calculations, implements the necessary service and repository logic, and updates error handling to support the new functionality.

**Core balance calculation feature:**

- Added a new `CoreService` (`server/src/services/core.rs`) that aggregates transactions and expenses to compute group and user balances, leveraging a new `core` function. The service fetches all historic group members, transactions, and expenses, then returns a structured balance summary.
- Implemented a new handler (`get_balances` in `server/src/handlers/core.rs`) and registered a `/core/balances/{group_id}` route (`server/src/routes/core.rs`, `server/src/router.rs`) that returns group and user balances for a given group, protected by authentication and group membership middleware. [[1]](diffhunk://#diff-950a7d0a2bc2f09c4cbc408680e31f7a78f028e6b94fd7badbd8805cbc078ceeR1-R34) [[2]](diffhunk://#diff-c65de8ce7febaff1627be1696612aa889341dba0fbde4638b645bbeed067785cR1-R18) [[3]](diffhunk://#diff-791d0d890b72e2a59dc720d055a6288a5cb6875592bbcf431d0c6ff51e87ea43R12) [[4]](diffhunk://#diff-791d0d890b72e2a59dc720d055a6288a5cb6875592bbcf431d0c6ff51e87ea43R39)

**Repository and data layer updates:**

- Extended the `GroupRepository` trait and its Diesel implementation to support fetching all historic group members, not just current members, via a new `get_historic_group_members` method. [[1]](diffhunk://#diff-f744c1eff5c28bc71e29818133a315d444dcc7e21946d6d5f924b4b2f2f043d7R20) [[2]](diffhunk://#diff-f8ed2226b0c841831aae7a6d7cce8c512ddbc1ae3554b06586125313e9b0ae1cR126-R147)

**Error handling improvements:**

- Added a new `Core` variant to the `AppError` enum and mapped it to HTTP 409 Conflict responses for error cases in core calculations. [[1]](diffhunk://#diff-ef5bec7cf04f4fc6e15af6097bf4e5485b77dc32ac795bbfc973b34f3ebfe5ddR34-R36) [[2]](diffhunk://#diff-ef5bec7cf04f4fc6e15af6097bf4e5485b77dc32ac795bbfc973b34f3ebfe5ddR54)

**Wiring and module organization:**

- Registered the new `CoreService` in the application state and dependency injection setup (`server/src/data/state.rs`, `server/src/main.rs`), and updated module imports/exports accordingly. [[1]](diffhunk://#diff-dc62d1e04fb81342a3b5ea387f3d2348c8bf6b4b779fcaa890e3986ebcfff3caR2) [[2]](diffhunk://#diff-dc62d1e04fb81342a3b5ea387f3d2348c8bf6b4b779fcaa890e3986ebcfff3caR25) [[3]](diffhunk://#diff-01fd5002f7585d6f2b853a8c83e6c0a1acb2b16b6e6f8f581fb3365377d331bcR37) [[4]](diffhunk://#diff-01fd5002f7585d6f2b853a8c83e6c0a1acb2b16b6e6f8f581fb3365377d331bcR84-R88) [[5]](diffhunk://#diff-01fd5002f7585d6f2b853a8c83e6c0a1acb2b16b6e6f8f581fb3365377d331bcR99) [[6]](diffhunk://#diff-a06604e329fa4a62f4500cc1d274eb2e2f6e232cd287aa43de577d483a9e1dabR2) [[7]](diffhunk://#diff-a06604e329fa4a62f4500cc1d274eb2e2f6e232cd287aa43de577d483a9e1dabR2) [[8]](diffhunk://#diff-a06604e329fa4a62f4500cc1d274eb2e2f6e232cd287aa43de577d483a9e1dabR2)

These changes collectively enable a new, authenticated API endpoint for retrieving comprehensive group and user financial balances.