### PR TITLE
Feature: agrego mensajes a forbidden y traduzco todos los mensajes de error

### DIFF
--- a/server/src/errors/app_error.rs
+++ b/server/src/errors/app_error.rs
@@ -30,7 +30,7 @@ pub enum AppError {
     Unauthorized,
 
     #[error("Forbidden")]
-    Forbidden,
+    Forbidden(String),
 
     #[error("Core operation failed")]
     Core,
@@ -50,7 +50,7 @@ impl IntoResponse for AppError {
             AppError::Internal => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
             AppError::PasswordHash(err) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
             AppError::Unauthorized => (StatusCode::UNAUTHORIZED, self.to_string()),
-            AppError::Forbidden => (StatusCode::FORBIDDEN, self.to_string()),
+            AppError::Forbidden(msg) => (StatusCode::FORBIDDEN, msg),
             AppError::Core => (StatusCode::CONFLICT, self.to_string()),
         };
 

--- a/server/src/services/auth.rs
+++ b/server/src/services/auth.rs
@@ -24,16 +24,16 @@ impl AuthService {
 
     pub fn register_user(&self, user: RegisterRequest) -> Result<User, AppError> {
         // Validate data
-        let name = require_non_empty(user.name, "Name")?;
+        let name = require_non_empty(user.name, "Nombre")?;
         let email = require_non_empty(user.email, "Email")?;
-        let password = require_non_empty(user.password, "Password")?;
+        let password = require_non_empty(user.password, "Contraseña")?;
 
         let valid = ValidateEmail::validate_email(&email)
             && ValidateLength::validate_length(&password, Some(5), Some(30), None)
             && ValidateLength::validate_length(&name.trim(), Some(2), Some(50), None);
 
         if !valid {
-            return Err(AppError::BadRequest("Invalid registration data".into()));
+            return Err(AppError::BadRequest("Datos de registro inválidos".into()));
         }
 
         let password_hash =
@@ -47,7 +47,7 @@ impl AuthService {
     pub fn login_user(&self, user: LoginRequest) -> Result<String, AppError> {
         // Validate data
         let email = require_non_empty(user.email, "Email")?;
-        let password = require_non_empty(user.password, "Password")?;
+        let password = require_non_empty(user.password, "Contraseña")?;
 
         let valid = ValidateEmail::validate_email(&email)
             && ValidateLength::validate_length(&password, Some(5), Some(30), None);

--- a/server/src/services/expense.rs
+++ b/server/src/services/expense.rs
@@ -82,7 +82,9 @@ impl ExpenseService {
         let expense = self.get_active(expense_id)?;
 
         if expense.user_id != user_id {
-            return Err(AppError::Forbidden);
+            return Err(AppError::Forbidden(
+                "Solo el creador o el admin pueden editar".into(),
+            ));
         }
 
         self.apply_update(&expense, payload)
@@ -100,8 +102,11 @@ impl ExpenseService {
     ) -> Result<Expense, AppError> {
         let expense = self.get_active(expense_id)?;
 
+        //aca en vez de tirar forbidden y decir que esa expense no pertenece a este grupo
+        //tiro not found asi no pueden saber si esa expense existe o no
+        //porque es de otro grupo
         if expense.group_id != group_id {
-            return Err(AppError::Forbidden);
+            return Err(AppError::NotFound);
         }
 
         self.apply_update(&expense, payload)
@@ -113,7 +118,9 @@ impl ExpenseService {
         let expense = self.get_active(expense_id)?;
 
         if expense.user_id != user_id {
-            return Err(AppError::Forbidden);
+            return Err(AppError::Forbidden(
+                "Solo el creador o el admin pueden editar".into(),
+            ));
         }
 
         let result = self.expense_repo.soft_delete(expense_id)?;
@@ -125,8 +132,9 @@ impl ExpenseService {
     pub fn delete_as_admin(&self, group_id: Uuid, expense_id: Uuid) -> Result<Expense, AppError> {
         let expense = self.get_active(expense_id)?;
 
+        //misma razon del not found de mas arriba
         if expense.group_id != group_id {
-            return Err(AppError::Forbidden);
+            return Err(AppError::NotFound);
         }
 
         let result = self.expense_repo.soft_delete(expense_id)?;

--- a/server/src/services/expense.rs
+++ b/server/src/services/expense.rs
@@ -148,7 +148,7 @@ impl ExpenseService {
             .ok_or(AppError::NotFound)?;
 
         if expense.status == MyExpenseStatus::Deleted {
-            return Err(AppError::BadRequest("Expense is already deleted".into()));
+            return Err(AppError::BadRequest("El gasto ya fue eliminado".into()));
         }
 
         Ok(expense)
@@ -169,7 +169,7 @@ impl ExpenseService {
             && description.is_none()
             && participants.is_none()
         {
-            return Err(AppError::BadRequest("No fields to update".into()));
+            return Err(AppError::BadRequest("No hay campos para actualizar".into()));
         }
 
         // Monto efectivo que tendrá la expense tras el update.
@@ -207,7 +207,7 @@ impl ExpenseService {
 
     fn validate_amount(amount: &BigDecimal) -> Result<(), AppError> {
         if amount <= &BigDecimal::zero() {
-            return Err(AppError::BadRequest("Amount must be greater than 0".into()));
+            return Err(AppError::BadRequest("El monto debe ser mayor a 0".into()));
         }
         Ok(())
     }
@@ -215,7 +215,7 @@ impl ExpenseService {
     fn validate_participants(participants: &[ParticipantInput]) -> Result<(), AppError> {
         if participants.is_empty() {
             return Err(AppError::BadRequest(
-                "Expense must have at least one participant".into(),
+                "El gasto debe tener al menos un participante".into(),
             ));
         }
 
@@ -224,7 +224,7 @@ impl ExpenseService {
         for p in participants {
             if !seen.insert(p.user_id) {
                 return Err(AppError::BadRequest(
-                    "Duplicated participant in expense".into(),
+                    "Hay un participante duplicado en el gasto".into(),
                 ));
             }
         }
@@ -237,7 +237,7 @@ impl ExpenseService {
         participants_len: usize,
     ) -> Result<BigDecimal, AppError> {
         let participants_count = i64::try_from(participants_len)
-            .map_err(|_| AppError::BadRequest("Too many participants".into()))?;
+            .map_err(|_| AppError::BadRequest("Hay demasiados participantes".into()))?;
         let divisor = BigDecimal::from(participants_count);
         Ok(total / divisor)
     }

--- a/server/src/services/expense.rs
+++ b/server/src/services/expense.rs
@@ -102,9 +102,7 @@ impl ExpenseService {
     ) -> Result<Expense, AppError> {
         let expense = self.get_active(expense_id)?;
 
-        //aca en vez de tirar forbidden y decir que esa expense no pertenece a este grupo
-        //tiro not found asi no pueden saber si esa expense existe o no
-        //porque es de otro grupo
+        // Return NotFound to avoid disclosing whether the expense exists in another group.
         if expense.group_id != group_id {
             return Err(AppError::NotFound);
         }

--- a/server/src/services/group.rs
+++ b/server/src/services/group.rs
@@ -79,7 +79,9 @@ impl GroupService {
 
     pub fn delete(&self, user_id: Uuid, group_id: Uuid) -> Result<Group, AppError> {
         if !self.is_admin(user_id, group_id)? {
-            return Err(AppError::Forbidden);
+            return Err(AppError::Forbidden(
+                "Solo el admin puede borrar el grupo".into(),
+            ));
         }
 
         let result = self.group_repo.delete_group(group_id)?;
@@ -124,7 +126,9 @@ impl GroupService {
         update: GroupUpdate,
     ) -> Result<Group, AppError> {
         if !self.is_admin(user_id, group_id)? {
-            return Err(AppError::Forbidden);
+            return Err(AppError::Forbidden(
+                "Solo el admin puede actualizar el grupo.".into(),
+            ));
         }
 
         if update.name.is_none() && update.description.is_none() {

--- a/server/src/services/group.rs
+++ b/server/src/services/group.rs
@@ -26,15 +26,15 @@ impl GroupService {
     }
 
     pub fn create_group(&self, group: NewGroupRequest, id: Uuid) -> Result<Uuid, AppError> {
-        let name = require_non_empty(group.name, "Name")?;
-        let description = require_non_empty(group.description, "Description")?;
+        let name = require_non_empty(group.name, "Nombre")?;
+        let description = require_non_empty(group.description, "Descripción")?;
 
         let valid = ValidateLength::validate_length(&name, Some(4), Some(30), None)
             && ValidateLength::validate_length(&description, Some(8), Some(30), None);
 
         if !valid {
             return Err(AppError::BadRequest(
-                "Invalid group name or description".into(),
+                "Nombre o descripción del grupo inválidos".into(),
             ));
         }
 
@@ -65,12 +65,16 @@ impl GroupService {
     pub fn make_admin(&self, user_id: Uuid, group_id: Uuid) -> Result<UserInGroup, AppError> {
         // Validate if user in group
         if !self.group_repo.is_member(user_id, group_id)? {
-            return Err(AppError::BadRequest("User not in group".into()));
+            return Err(AppError::BadRequest(
+                "El usuario no pertenece al grupo".into(),
+            ));
         }
 
         // Validate if not admin
         if self.is_admin(user_id, group_id)? {
-            return Err(AppError::BadRequest("User is already an admin".into()));
+            return Err(AppError::BadRequest(
+                "El usuario ya es administrador".into(),
+            ));
         }
 
         let result = self.group_repo.make_admin(user_id, group_id)?;
@@ -80,7 +84,7 @@ impl GroupService {
     pub fn delete(&self, user_id: Uuid, group_id: Uuid) -> Result<Group, AppError> {
         if !self.is_admin(user_id, group_id)? {
             return Err(AppError::Forbidden(
-                "Solo el admin puede borrar el grupo".into(),
+                "Solo el administrador puede borrar el grupo".into(),
             ));
         }
 
@@ -109,7 +113,7 @@ impl GroupService {
 
             if !has_other_admin {
                 return Err(AppError::BadRequest(
-                    "El grupo tiene que tener al menos un admin".into(),
+                    "El grupo tiene que tener al menos un administrador".into(),
                 ));
             }
         }
@@ -127,18 +131,18 @@ impl GroupService {
     ) -> Result<Group, AppError> {
         if !self.is_admin(user_id, group_id)? {
             return Err(AppError::Forbidden(
-                "Solo el admin puede actualizar el grupo.".into(),
+                "Solo el administrador puede actualizar el grupo.".into(),
             ));
         }
 
         if update.name.is_none() && update.description.is_none() {
-            return Err(AppError::BadRequest("No fields to update".into()));
+            return Err(AppError::BadRequest("No hay campos para actualizar".into()));
         }
 
         if let Some(ref name) = update.name {
             if !ValidateLength::validate_length(name.trim(), Some(4), Some(30), None) {
                 return Err(AppError::BadRequest(
-                    "Invalid group name: must be 4–30 characters".into(),
+                    "Nombre de grupo inválido: debe tener entre 4 y 30 caracteres".into(),
                 ));
             }
         }
@@ -146,7 +150,7 @@ impl GroupService {
         if let Some(ref description) = update.description {
             if !ValidateLength::validate_length(description.trim(), Some(8), Some(30), None) {
                 return Err(AppError::BadRequest(
-                    "Invalid group description: must be 8–30 characters".into(),
+                    "Descripción de grupo inválida: debe tener entre 8 y 30 caracteres".into(),
                 ));
             }
         }

--- a/server/src/services/group_wallet.rs
+++ b/server/src/services/group_wallet.rs
@@ -417,7 +417,7 @@ impl GroupWalletService {
 
     fn validate_is_admin(&self, user_id: Uuid, group_id: Uuid) -> Result<(), AppError> {
         if !self.group_repo.is_admin(user_id, group_id)? {
-            return Err(AppError::Forbidden("no es admin del grupo".into()));
+            return Err(AppError::Forbidden("No es admin del grupo".into()));
         }
         Ok(())
     }

--- a/server/src/services/group_wallet.rs
+++ b/server/src/services/group_wallet.rs
@@ -311,7 +311,9 @@ impl GroupWalletService {
 
         // Only the creator of the fund round can cancel it.
         if fund_round.proposal.created_by != user_id {
-            return Err(AppError::Forbidden);
+            return Err(AppError::Forbidden(
+                "Solo el creador la puede cancelar".into(),
+            ));
         }
 
         self.proposal_repo
@@ -408,14 +410,14 @@ impl GroupWalletService {
 
     fn validate_is_member(&self, user_id: Uuid, group_id: Uuid) -> Result<(), AppError> {
         if !self.group_repo.is_member(user_id, group_id)? {
-            return Err(AppError::Forbidden);
+            return Err(AppError::Forbidden("No es miembro del grupo".into()));
         }
         Ok(())
     }
 
     fn validate_is_admin(&self, user_id: Uuid, group_id: Uuid) -> Result<(), AppError> {
         if !self.group_repo.is_admin(user_id, group_id)? {
-            return Err(AppError::Forbidden);
+            return Err(AppError::Forbidden("no es admin del grupo".into()));
         }
         Ok(())
     }

--- a/server/src/services/group_wallet.rs
+++ b/server/src/services/group_wallet.rs
@@ -59,11 +59,11 @@ impl GroupWalletService {
     ) -> Result<FundProposalExpanded, AppError> {
         self.validate_is_admin(created_by, group_id)?;
         let target_amount = BigDecimal::from_str(&payload.target_amount)
-            .map_err(|_| AppError::BadRequest("Invalid target_amount".into()))?;
+            .map_err(|_| AppError::BadRequest("Monto objetivo inválido".into()))?;
 
         if target_amount <= BigDecimal::zero() {
             return Err(AppError::BadRequest(
-                "target_amount must be greater than zero".into(),
+                "El monto objetivo debe ser mayor a cero".into(),
             ));
         }
 
@@ -74,7 +74,7 @@ impl GroupWalletService {
             .is_some()
         {
             return Err(AppError::BadRequest(
-                "Group does not have a wallet with the specified currency".into(),
+                "El grupo no tiene una wallet con la moneda especificada".into(),
             ));
         }
 
@@ -95,11 +95,11 @@ impl GroupWalletService {
 
     fn parse_positive_amount(&self, raw: String) -> Result<BigDecimal, AppError> {
         let amount = BigDecimal::from_str(&raw)
-            .map_err(|_| AppError::BadRequest("Invalid amount".into()))?;
+            .map_err(|_| AppError::BadRequest("Monto inválido".into()))?;
 
         if amount <= BigDecimal::zero() {
             return Err(AppError::BadRequest(
-                "amount must be greater than zero".into(),
+                "El monto debe ser mayor a cero".into(),
             ));
         }
         Ok(amount)
@@ -112,7 +112,9 @@ impl GroupWalletService {
         let found = self.find_fund_round(fund_round_id)?;
 
         if found.proposal.status != MyProposalStatus::Approved {
-            return Err(AppError::BadRequest("Fund round is not active".into()));
+            return Err(AppError::BadRequest(
+                "La ronda de fondeo no está activa".into(),
+            ));
         }
 
         Ok(found)
@@ -128,7 +130,7 @@ impl GroupWalletService {
         )? {
             Some(wallet) => Ok(wallet),
             None => Err(AppError::BadRequest(
-                "Group does not have a wallet with the specified currency".into(),
+                "El grupo no tiene una wallet con la moneda especificada".into(),
             )),
         }
     }
@@ -143,24 +145,28 @@ impl GroupWalletService {
         let sender_wallet = match self.user_wallet_repo.get_wallet_info(sender_wallet_id) {
             Ok(wallet) => wallet,
             Err(DbError::Diesel(Error::NotFound)) => {
-                return Err(AppError::BadRequest("Sender wallet not found".into()));
+                return Err(AppError::BadRequest(
+                    "No se encontró la wallet de origen".into(),
+                ));
             }
             Err(err) => return Err(AppError::Db(err)),
         };
 
         if sender_wallet.user_id != user_id {
-            return Err(AppError::BadRequest("Sender wallet not found".into()));
+            return Err(AppError::BadRequest(
+                "No se encontró la wallet de origen".into(),
+            ));
         }
 
         if sender_wallet.currency_id != expected_currency_id {
             return Err(AppError::BadRequest(
-                "Sender wallet currency does not match fund round currency".into(),
+                "La moneda de la wallet de origen no coincide con la de la ronda de fondeo".into(),
             ));
         }
 
         // Pre-check UX (el repo igual lo revalida transaccionalmente)
         if sender_wallet.balance < *amount {
-            return Err(AppError::BadRequest("Insufficient funds".into()));
+            return Err(AppError::BadRequest("Fondos insuficientes".into()));
         }
 
         Ok(())
@@ -195,7 +201,7 @@ impl GroupWalletService {
             )
             .map_err(|err| match err {
                 DbError::Diesel(Error::NotFound) => AppError::BadRequest(
-                    "Fund round is not active, insufficient funds, or amount exceeds remaining target".into(),
+                    "La ronda de fondeo no está activa, no hay fondos suficientes o el monto supera el objetivo restante".into(),
                 ),
                 err => AppError::Db(err),
             })?;
@@ -278,7 +284,7 @@ impl GroupWalletService {
 
         if remaining < BigDecimal::zero() {
             return Err(AppError::BadRequest(
-                "Fund round is not active, insufficient funds, or amount exceeds remaining target"
+                "La ronda de fondeo no está activa, no hay fondos suficientes o el monto supera el objetivo restante"
                     .into(),
             ));
         }
@@ -306,7 +312,9 @@ impl GroupWalletService {
         let fund_round = self.find_fund_round(fund_round_id)?;
 
         if fund_round.proposal.status != MyProposalStatus::Approved {
-            return Err(AppError::BadRequest("Fund round is not active".into()));
+            return Err(AppError::BadRequest(
+                "La ronda de fondeo no está activa".into(),
+            ));
         }
 
         // Only the creator of the fund round can cancel it.
@@ -341,7 +349,7 @@ impl GroupWalletService {
         {
             Ok(currency_id) => currency_id,
             Err(DbError::Diesel(Error::NotFound)) => {
-                return Err(AppError::BadRequest("That currency doesn't exist".into()));
+                return Err(AppError::BadRequest("Esa moneda no existe".into()));
             }
             Err(err) => return Err(AppError::Db(err)),
         };
@@ -353,7 +361,7 @@ impl GroupWalletService {
 
         if existing.is_some() {
             return Err(AppError::BadRequest(
-                "The group already has a wallet for this currency".into(),
+                "El grupo ya tiene una wallet para esa moneda".into(),
             ));
         }
 
@@ -364,7 +372,7 @@ impl GroupWalletService {
 
         if address_taken.is_some() {
             return Err(AppError::BadRequest(
-                "That address is already registered for this currency".into(),
+                "Esa dirección ya está registrada para esa moneda".into(),
             ));
         }
 
@@ -417,7 +425,7 @@ impl GroupWalletService {
 
     fn validate_is_admin(&self, user_id: Uuid, group_id: Uuid) -> Result<(), AppError> {
         if !self.group_repo.is_admin(user_id, group_id)? {
-            return Err(AppError::Forbidden("No es admin del grupo".into()));
+            return Err(AppError::Forbidden("No es administrador del grupo".into()));
         }
         Ok(())
     }

--- a/server/src/services/proposal.rs
+++ b/server/src/services/proposal.rs
@@ -167,7 +167,7 @@ impl ProposalService {
             ));
         }
         if search_proposal.proposal.status != MyProposalStatus::Approved {
-            return Err(AppError::Forbidden(
+            return Err(AppError::BadRequest(
                 "Esta invitación ya fue aceptada o rechazada".into(),
             ));
         }

--- a/server/src/services/proposal.rs
+++ b/server/src/services/proposal.rs
@@ -98,14 +98,14 @@ impl ProposalService {
             (None, Some(user_id)) => self
                 .user_repo
                 .find_by_id(user_id)?
-                .ok_or(AppError::BadRequest("User not found".to_string()))?,
+                .ok_or(AppError::BadRequest("Usuario no encontrado".to_string()))?,
             (Some(email), _) => self
                 .user_repo
                 .find_by_email(email)?
-                .ok_or(AppError::BadRequest("User not found".to_string()))?,
+                .ok_or(AppError::BadRequest("Usuario no encontrado".to_string()))?,
             (None, None) => {
                 return Err(AppError::BadRequest(
-                    "Either user_id or user_email must be provided".to_string(),
+                    "Se debe enviar user_id o user_email".to_string(),
                 ));
             }
         };
@@ -113,7 +113,7 @@ impl ProposalService {
         // validate: new_user not in group
         if self.group_repo.is_member(user.id, group_id)? {
             return Err(AppError::BadRequest(
-                "User is already a member of the group".to_string(),
+                "El usuario ya pertenece al grupo".to_string(),
             ));
         }
 
@@ -183,7 +183,7 @@ impl ProposalService {
             next_status,
         ) {
             Ok(proposal) => Ok(proposal),
-            Err(_) => Err(AppError::BadRequest("invalid request".parse().unwrap())),
+            Err(_) => Err(AppError::BadRequest("Solicitud inválida".parse().unwrap())),
         }
     }
 
@@ -209,7 +209,7 @@ impl ProposalService {
 
         if group.id != group_id {
             return Err(AppError::BadRequest(
-                "Proposal does not belong to the group".to_string(),
+                "La propuesta no pertenece al grupo".to_string(),
             ));
         }
 
@@ -227,13 +227,13 @@ impl ProposalService {
     fn find_proposal(&self, proposal_id: Uuid) -> Result<Proposal, AppError> {
         self.proposal_repo
             .find(proposal_id)?
-            .ok_or(AppError::BadRequest("Proposal does not exist".to_string()))
+            .ok_or(AppError::BadRequest("La propuesta no existe".to_string()))
     }
 
     fn find_group(&self, group_id: Uuid) -> Result<Group, AppError> {
         self.group_repo
             .find_by_id(group_id)?
-            .ok_or(AppError::BadRequest("Group does not exist".to_string()))
+            .ok_or(AppError::BadRequest("El grupo no existe".to_string()))
     }
 
     pub fn get_all_withdraw_proposals(

--- a/server/src/services/proposal.rs
+++ b/server/src/services/proposal.rs
@@ -162,10 +162,14 @@ impl ProposalService {
             .proposal_repo
             .find_new_member_proposal_by_proposal_id(new_member_proposal_id)?;
         if search_proposal.new_member_proposal.new_member_id != destination {
-            return Err(AppError::Forbidden);
+            return Err(AppError::Forbidden(
+                "No podes aceptar una invitacion que no es tuya".into(),
+            ));
         }
         if search_proposal.proposal.status != MyProposalStatus::Approved {
-            return Err(AppError::Forbidden);
+            return Err(AppError::Forbidden(
+                "Esta invitación ya fue aceptada o rechazada".into(),
+            ));
         }
         let next_status = if approve {
             MyProposalStatus::Executed

--- a/server/src/services/transaction.rs
+++ b/server/src/services/transaction.rs
@@ -37,24 +37,24 @@ impl TransactionService {
         payload: FundGroupRequest,
     ) -> Result<Transaction, AppError> {
         if payload.amount <= BigDecimal::zero() {
-            return Err(AppError::BadRequest("Amount must be greater than 0".into()));
+            return Err(AppError::BadRequest("El monto debe ser mayor a 0".into()));
         }
 
         let user_wallet = self
             .transaction_repo
             .get_user_wallet(user_id, payload.address.clone(), payload.currency_id)?
             .ok_or(AppError::BadRequest(
-                "User does not have a wallet for this currency".into(),
+                "El usuario no tiene una wallet para esta moneda".into(),
             ))?;
 
         if user_wallet.balance < payload.amount {
-            return Err(AppError::BadRequest("Insufficient balance".into()));
+            return Err(AppError::BadRequest("Saldo insuficiente".into()));
         }
 
         self.transaction_repo
             .get_group_wallet(group_id, payload.currency_id)?
             .ok_or(AppError::BadRequest(
-                "Group does not have a wallet for this currency".into(),
+                "El grupo no tiene una wallet para esta moneda".into(),
             ))?;
 
         let new_tx = NewTransaction {
@@ -84,24 +84,24 @@ impl TransactionService {
         }: WithdrawProposalRequest,
     ) -> Result<WithdrawProposalExpanded, AppError> {
         if amount <= BigDecimal::zero() {
-            return Err(AppError::BadRequest("Amount must be greater than 0".into()));
+            return Err(AppError::BadRequest("El monto debe ser mayor a 0".into()));
         }
 
         let group_wallet = self
             .transaction_repo
             .get_group_wallet(group_id, currency_id)?
             .ok_or(AppError::BadRequest(
-                "Group does not have a wallet for this currency".into(),
+                "El grupo no tiene una wallet para esta moneda".into(),
             ))?;
 
         if group_wallet.balance < amount {
-            return Err(AppError::BadRequest("Insufficient group balance".into()));
+            return Err(AppError::BadRequest("Saldo insuficiente del grupo".into()));
         }
 
         self.transaction_repo
             .get_user_wallet(user_id, address, currency_id)?
             .ok_or(AppError::BadRequest(
-                "User does not have a wallet for this currency".into(),
+                "El usuario no tiene una wallet para esta moneda".into(),
             ))?;
 
         let result =
@@ -128,9 +128,9 @@ impl TransactionService {
 
         let expanded_valid = match expanded.proposal.status {
             MyProposalStatus::Approved => Ok(expanded),
-            MyProposalStatus::Executed => Err(AppError::BadRequest(
-                "Proposal has already been executed".into(),
-            )),
+            MyProposalStatus::Executed => {
+                Err(AppError::BadRequest("Propuesta ya fue ejecutada".into()))
+            }
             _ => Err(AppError::NotFound),
         }?;
 
@@ -147,17 +147,17 @@ impl TransactionService {
             .transaction_repo
             .get_group_wallet(group_id, currency_id)?
             .ok_or(AppError::BadRequest(
-                "Group does not have a wallet for this currency".into(),
+                "Grupo no tiene una dirección para esa moneda".into(),
             ))?;
 
         if group_wallet.balance < expanded_valid.withdraw_proposal.amount {
-            return Err(AppError::BadRequest("Insufficient group balance".into()));
+            return Err(AppError::BadRequest("Fondo de grupo insuficiente".into()));
         }
 
         self.transaction_repo
             .get_user_wallet(user_id, address.clone(), currency_id)?
             .ok_or(AppError::BadRequest(
-                "User does not have a wallet for this currency".into(),
+                "El usuario no tiene una wallet para esa moneda".into(),
             ))?;
 
         let new_tx = NewTransaction {

--- a/server/src/services/transaction.rs
+++ b/server/src/services/transaction.rs
@@ -135,11 +135,13 @@ impl TransactionService {
         }?;
 
         if expanded_valid.proposal.group_id != group_id {
-            return Err(AppError::Forbidden);
+            return Err(AppError::NotFound);
         }
 
         if expanded_valid.proposal.created_by != user_id {
-            return Err(AppError::Forbidden);
+            return Err(AppError::Forbidden(
+                "Solo el creador la puede ejecutar".into(),
+            ));
         }
         let group_wallet = self
             .transaction_repo
@@ -187,7 +189,7 @@ impl TransactionService {
             .ok_or(AppError::NotFound)?;
 
         if tx.group_id != group_id {
-            return Err(AppError::Forbidden);
+            return Err(AppError::NotFound);
         }
 
         Ok(tx)

--- a/server/src/services/user.rs
+++ b/server/src/services/user.rs
@@ -19,10 +19,12 @@ impl UserService {
     }
 
     pub fn create_user(&self, user: CreateUserRequest) -> Result<User, AppError> {
-        let name = user.name.ok_or(AppError::BadRequest("Name empty".into()))?;
+        let name = user
+            .name
+            .ok_or(AppError::BadRequest("Nombre vacío".into()))?;
         let email = user
             .email
-            .ok_or(AppError::BadRequest("Email empty".into()))?;
+            .ok_or(AppError::BadRequest("Email vacío".into()))?;
 
         let user = self.repo.create(name, email)?;
 

--- a/server/src/services/user_wallet.rs
+++ b/server/src/services/user_wallet.rs
@@ -44,7 +44,9 @@ impl UserWalletService {
 
         if let Some(owner_id) = owner_opt {
             if owner_id != user_id {
-                return Err(AppError::Forbidden);
+                return Err(AppError::Forbidden(
+                    "Esa address ya esta tomada, elija otra".into(),
+                ));
             }
         }
 
@@ -55,7 +57,7 @@ impl UserWalletService {
             .map_err(AppError::Db)?;
 
         if existing_currency_wallet.is_some() {
-            return Err(AppError::Forbidden);
+            return Err(AppError::Forbidden("Esa currency no existe".into()));
         }
 
         //la creo
@@ -85,7 +87,9 @@ impl UserWalletService {
             .map_err(AppError::Db)?;
 
         if wallet.user_id != user_id {
-            return Err(AppError::Forbidden);
+            return Err(AppError::Forbidden(
+                "No podes fondear una wallet que no es tuya".into(),
+            ));
         }
         self.user_wallet_repo
             .add_money_to_wallet(wallet_id, amount)
@@ -106,7 +110,9 @@ impl UserWalletService {
             .map_err(AppError::Db)?;
 
         if wallet.user_id != current_user_id {
-            return Err(AppError::Forbidden);
+            return Err(AppError::Forbidden(
+                "No podes retirar de una wallet que no es tuya".into(),
+            ));
         }
         if wallet.balance < amount {
             return Err(AppError::BadRequest("Insuficient funds".into()));
@@ -134,7 +140,9 @@ impl UserWalletService {
             .map_err(|_| AppError::BadRequest("wallet doesn't exist".into()))?;
 
         if sender_wallet.user_id != current_user_id {
-            return Err(AppError::Forbidden);
+            return Err(AppError::Forbidden(
+                "No podes retirar de una wallet que no es tuya".into(),
+            ));
         }
 
         if sender_wallet.balance < amount {
@@ -179,7 +187,7 @@ impl UserWalletService {
             .map_err(AppError::Db)?;
 
         if wallet.user_id != user_id {
-            return Err(AppError::Forbidden);
+            return Err(AppError::Forbidden("Esta wallet no es tuya".into()));
         }
         Ok(wallet)
     }
@@ -206,7 +214,7 @@ impl UserWalletService {
             .map_err(AppError::Db)?;
 
         if wallet.user_id != current_user_id {
-            return Err(AppError::Forbidden);
+            return Err(AppError::Forbidden("Esta wallet no es tuya".into()));
         }
 
         Ok(wallet)
@@ -232,7 +240,7 @@ impl UserWalletService {
             .map_err(AppError::Db)?;
 
         if !is_owner {
-            return Err(AppError::Forbidden);
+            return Err(AppError::Forbidden("Esta wallet no es tuya".into()));
         }
 
         Ok(wallet_id)

--- a/server/src/services/user_wallet.rs
+++ b/server/src/services/user_wallet.rs
@@ -57,7 +57,9 @@ impl UserWalletService {
             .map_err(AppError::Db)?;
 
         if existing_currency_wallet.is_some() {
-            return Err(AppError::Forbidden("Esa currency no existe".into()));
+            return Err(AppError::Forbidden(
+                "Esa address ya esta registrada para esa currency".into(),
+            ));
         }
 
         //la creo

--- a/server/src/services/user_wallet.rs
+++ b/server/src/services/user_wallet.rs
@@ -34,7 +34,7 @@ impl UserWalletService {
         let currency_id = self
             .currency_repo
             .get_currency_id_by_ticker(wallet_request.currency_ticker.clone())
-            .map_err(|_| AppError::BadRequest("that currency doesn't exist".into()))?;
+            .map_err(|_| AppError::BadRequest("Esa moneda no existe".into()))?;
 
         //chequeo si el user ya tiene esa address asignada por otra currency
         let owner_opt = self
@@ -45,7 +45,7 @@ impl UserWalletService {
         if let Some(owner_id) = owner_opt {
             if owner_id != user_id {
                 return Err(AppError::Forbidden(
-                    "Esa address ya esta tomada, elija otra".into(),
+                    "Esa dirección ya está tomada, elegí otra".into(),
                 ));
             }
         }
@@ -58,7 +58,7 @@ impl UserWalletService {
 
         if existing_currency_wallet.is_some() {
             return Err(AppError::Forbidden(
-                "Esa address ya esta registrada para esa currency".into(),
+                "Esa dirección ya está registrada para esa moneda".into(),
             ));
         }
 
@@ -80,7 +80,9 @@ impl UserWalletService {
         amount: BigDecimal,
     ) -> Result<UserWallet, AppError> {
         if amount <= BigDecimal::zero() {
-            return Err(AppError::BadRequest("amount must be higher than 0".into()));
+            return Err(AppError::BadRequest(
+                "La cantidad tiene que ser mayor a 0".into(),
+            ));
         }
 
         let wallet = self
@@ -104,7 +106,9 @@ impl UserWalletService {
         amount: BigDecimal,
     ) -> Result<UserWallet, AppError> {
         if amount <= BigDecimal::zero() {
-            return Err(AppError::BadRequest("amount must be higher than 0".into()));
+            return Err(AppError::BadRequest(
+                "La cantidad tiene que ser mayor a 0".into(),
+            ));
         }
         let wallet = self
             .user_wallet_repo
@@ -117,7 +121,7 @@ impl UserWalletService {
             ));
         }
         if wallet.balance < amount {
-            return Err(AppError::BadRequest("Insuficient funds".into()));
+            return Err(AppError::BadRequest("Fondos insuficientes".into()));
         }
 
         self.user_wallet_repo
@@ -133,13 +137,15 @@ impl UserWalletService {
             .map_err(|_| AppError::BadRequest("Monto inválido".into()))?;
 
         if amount <= BigDecimal::zero() {
-            return Err(AppError::BadRequest("Amount must be higher than 0".into()));
+            return Err(AppError::BadRequest(
+                "La cantidad tiene que ser mayor a 0".into(),
+            ));
         }
 
         let sender_wallet = self
             .user_wallet_repo
             .get_wallet_info(request.sender_wallet_id)
-            .map_err(|_| AppError::BadRequest("wallet doesn't exist".into()))?;
+            .map_err(|_| AppError::BadRequest("Esa wallet no existe".into()))?;
 
         if sender_wallet.user_id != current_user_id {
             return Err(AppError::Forbidden(
@@ -148,12 +154,12 @@ impl UserWalletService {
         }
 
         if sender_wallet.balance < amount {
-            return Err(AppError::BadRequest("Insuficient funds".into()));
+            return Err(AppError::BadRequest("Fondos insuficientes".into()));
         }
 
         if sender_wallet.address == request.receiver_address {
             return Err(AppError::BadRequest(
-                "You can't transfer to the same address".into(),
+                "No podés transferir a la misma dirección".into(),
             ));
         }
 
@@ -169,7 +175,7 @@ impl UserWalletService {
             Some(id) => id,
             None => {
                 return Err(AppError::BadRequest(
-                    "Receiver wallet doesn't exist or doesn't support this currency".into(),
+                    "Esa dirección no existe o no soporta esta moneda".into(),
                 ));
             }
         };
@@ -202,7 +208,7 @@ impl UserWalletService {
         let currency_id = self
             .currency_repo
             .get_currency_id_by_ticker(ticker)
-            .map_err(|_| AppError::BadRequest("that currency doesn't exist".into()))?;
+            .map_err(|_| AppError::BadRequest("Esa moneda no existe".into()))?;
 
         let wallet_id = self
             .user_wallet_repo


### PR DESCRIPTION
This pull request improves the clarity and security of error handling across several service layers by enhancing the `Forbidden` error variant to include descriptive messages and by returning `NotFound` instead of `Forbidden` in certain group-related access checks. This provides users with more informative error messages and helps prevent information leakage about resource existence.

**Error Handling Improvements**

* The `AppError::Forbidden` variant now accepts a `String` message, allowing more descriptive and context-specific error responses throughout the codebase. [[1]](diffhunk://#diff-ef5bec7cf04f4fc6e15af6097bf4e5485b77dc32ac795bbfc973b34f3ebfe5ddL33-R33) [[2]](diffhunk://#diff-ef5bec7cf04f4fc6e15af6097bf4e5485b77dc32ac795bbfc973b34f3ebfe5ddL53-R53)
* All usages of `AppError::Forbidden` in service methods have been updated to include user-friendly, context-specific messages, improving API feedback for unauthorized actions. [[1]](diffhunk://#diff-4dde444875738bbf22df4a8edc01d35d1a59961d9090a17feb7f73860007d0e0L85-R87) [[2]](diffhunk://#diff-4dde444875738bbf22df4a8edc01d35d1a59961d9090a17feb7f73860007d0e0L116-R123) [[3]](diffhunk://#diff-d95ae3518dd80fd0d2c05c89fc26e28be59f7376e13c5f527b6a48af7592addaL82-R84) [[4]](diffhunk://#diff-d95ae3518dd80fd0d2c05c89fc26e28be59f7376e13c5f527b6a48af7592addaL127-R131) [[5]](diffhunk://#diff-6c906f7090616fccc8166197258433ad3e66770d3e73f866d712a0eadb5c4ecbL314-R316) [[6]](diffhunk://#diff-6c906f7090616fccc8166197258433ad3e66770d3e73f866d712a0eadb5c4ecbL411-R420) [[7]](diffhunk://#diff-fd8d9391a7404d1ee38da0b84c204583e9fafb64704d0800c8bd4827c4127c9cL165-R172) [[8]](diffhunk://#diff-cf62de0128db690860b51dd331ea1698ab5d0000f2bddde351646a93b04a763bL47-R49) [[9]](diffhunk://#diff-cf62de0128db690860b51dd331ea1698ab5d0000f2bddde351646a93b04a763bL58-R60) [[10]](diffhunk://#diff-cf62de0128db690860b51dd331ea1698ab5d0000f2bddde351646a93b04a763bL88-R92) [[11]](diffhunk://#diff-cf62de0128db690860b51dd331ea1698ab5d0000f2bddde351646a93b04a763bL109-R115) [[12]](diffhunk://#diff-cf62de0128db690860b51dd331ea1698ab5d0000f2bddde351646a93b04a763bL137-R145) [[13]](diffhunk://#diff-cf62de0128db690860b51dd331ea1698ab5d0000f2bddde351646a93b04a763bL182-R190) [[14]](diffhunk://#diff-cf62de0128db690860b51dd331ea1698ab5d0000f2bddde351646a93b04a763bL209-R217) [[15]](diffhunk://#diff-cf62de0128db690860b51dd331ea1698ab5d0000f2bddde351646a93b04a763bL235-R243) [[16]](diffhunk://#diff-6cd0edf48941d3428099ecf8e5e38c4cb255457fd0a321fcc11842bd896f20fcL138-R144)

**Security Enhancements**

* For cases where a user attempts to access or modify an expense or transaction belonging to a different group, the service now returns `AppError::NotFound` instead of `Forbidden`. This change prevents leaking information about the existence of resources in other groups. [[1]](diffhunk://#diff-4dde444875738bbf22df4a8edc01d35d1a59961d9090a17feb7f73860007d0e0R105-R109) [[2]](diffhunk://#diff-4dde444875738bbf22df4a8edc01d35d1a59961d9090a17feb7f73860007d0e0R135-R137) [[3]](diffhunk://#diff-6cd0edf48941d3428099ecf8e5e38c4cb255457fd0a321fcc11842bd896f20fcL138-R144) [[4]](diffhunk://#diff-6cd0edf48941d3428099ecf8e5e38c4cb255457fd0a321fcc11842bd896f20fcL190-R192)

These changes collectively make error responses more meaningful for users and improve the overall security posture of the application.