### PR TITLE
Feature: investment migrations and models

### DIFF
--- a/server/migrations/2026-05-23-141438-0000_investment_strategy/down.sql
+++ b/server/migrations/2026-05-23-141438-0000_investment_strategy/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS investment_strategy;

--- a/server/migrations/2026-05-23-141438-0000_investment_strategy/up.sql
+++ b/server/migrations/2026-05-23-141438-0000_investment_strategy/up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE investment_strategy (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    description TEXT NOT NULL,
+    risk_level TEXT NOT NULL CHECK (risk_level IN ('low', 'medium', 'high')),
+    expected_return_percentage NUMERIC NOT NULL CHECK (expected_return_percentage > 0),
+    duration_days INTEGER NOT NULL CHECK (duration_days > 0),
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO investment_strategy (name, description, risk_level, expected_return_percentage, duration_days) VALUES
+    ('Fondo Común Lemipay', 'Bajo riesgo, retorno estable y predecible', 'low', 3.0, 30),
+    ('TOP 100 ARG', 'Riesgo medio, buen retorno balanceado', 'medium', 7.5, 60),
+    ('Micheal Saylor', 'Alto riesgo, alto retorno potencial', 'high', 15.0, 90);

--- a/server/migrations/2026-05-23-141438-0000_investment_strategy/up.sql
+++ b/server/migrations/2026-05-23-141438-0000_investment_strategy/up.sql
@@ -11,4 +11,4 @@ CREATE TABLE investment_strategy (
 INSERT INTO investment_strategy (name, description, risk_level, expected_return_percentage, duration_days) VALUES
     ('Fondo Común Lemipay', 'Bajo riesgo, retorno estable y predecible', 'low', 3.0, 30),
     ('TOP 100 ARG', 'Riesgo medio, buen retorno balanceado', 'medium', 7.5, 60),
-    ('Micheal Saylor', 'Alto riesgo, alto retorno potencial', 'high', 15.0, 90);
+    ('Michael Saylor', 'Alto riesgo, alto retorno potencial', 'high', 15.0, 90);

--- a/server/migrations/2026-05-23-141439-0000_investment_proposal/down.sql
+++ b/server/migrations/2026-05-23-141439-0000_investment_proposal/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS investment_proposal;

--- a/server/migrations/2026-05-23-141439-0000_investment_proposal/up.sql
+++ b/server/migrations/2026-05-23-141439-0000_investment_proposal/up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE investment_proposal (
+    proposal_id UUID PRIMARY KEY REFERENCES proposal(id) ON DELETE CASCADE,
+    amount NUMERIC NOT NULL CHECK (amount > 0),
+    strategy_id UUID NOT NULL REFERENCES investment_strategy(id) ON DELETE RESTRICT,
+    currency_id UUID NOT NULL REFERENCES currency(currency_id) ON DELETE RESTRICT
+);

--- a/server/migrations/2026-05-23-141439-0001_investment/down.sql
+++ b/server/migrations/2026-05-23-141439-0001_investment/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS investment;
+DROP TYPE IF EXISTS investment_status;

--- a/server/migrations/2026-05-23-141439-0001_investment/up.sql
+++ b/server/migrations/2026-05-23-141439-0001_investment/up.sql
@@ -4,7 +4,7 @@ CREATE TABLE investment (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     proposal_id UUID NOT NULL REFERENCES investment_proposal(proposal_id) ON DELETE RESTRICT,
     amount NUMERIC NOT NULL CHECK (amount > 0),
-    expected_return NUMERIC NOT NULL CHECK (expected_return >= 0),
+    current_value NUMERIC NOT NULL,
     actual_return NUMERIC,
     status investment_status NOT NULL DEFAULT 'active',
     started_at TIMESTAMP NOT NULL DEFAULT NOW(),

--- a/server/migrations/2026-05-23-141439-0001_investment/up.sql
+++ b/server/migrations/2026-05-23-141439-0001_investment/up.sql
@@ -2,7 +2,7 @@ CREATE TYPE investment_status AS ENUM ('active', 'matured', 'withdrawn');
 
 CREATE TABLE investment (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    proposal_id UUID NOT NULL REFERENCES proposal(id) ON DELETE RESTRICT,
+    proposal_id UUID NOT NULL REFERENCES investment_proposal(proposal_id) ON DELETE RESTRICT,
     amount NUMERIC NOT NULL CHECK (amount > 0),
     expected_return NUMERIC NOT NULL CHECK (expected_return >= 0),
     actual_return NUMERIC,

--- a/server/migrations/2026-05-23-141439-0001_investment/up.sql
+++ b/server/migrations/2026-05-23-141439-0001_investment/up.sql
@@ -2,10 +2,7 @@ CREATE TYPE investment_status AS ENUM ('active', 'matured', 'withdrawn');
 
 CREATE TABLE investment (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    group_id UUID NOT NULL REFERENCES "group"(id) ON DELETE CASCADE,
     proposal_id UUID NOT NULL REFERENCES proposal(id) ON DELETE RESTRICT,
-    strategy_id UUID NOT NULL REFERENCES investment_strategy(id) ON DELETE RESTRICT,
-    currency_id UUID NOT NULL REFERENCES currency(currency_id) ON DELETE RESTRICT,
     amount NUMERIC NOT NULL CHECK (amount > 0),
     expected_return NUMERIC NOT NULL CHECK (expected_return >= 0),
     actual_return NUMERIC,

--- a/server/migrations/2026-05-23-141439-0001_investment/up.sql
+++ b/server/migrations/2026-05-23-141439-0001_investment/up.sql
@@ -1,0 +1,17 @@
+CREATE TYPE investment_status AS ENUM ('active', 'matured', 'withdrawn');
+
+CREATE TABLE investment (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    group_id UUID NOT NULL REFERENCES "group"(id) ON DELETE CASCADE,
+    proposal_id UUID NOT NULL REFERENCES proposal(id) ON DELETE RESTRICT,
+    strategy_id UUID NOT NULL REFERENCES investment_strategy(id) ON DELETE RESTRICT,
+    currency_id UUID NOT NULL REFERENCES currency(currency_id) ON DELETE RESTRICT,
+    amount NUMERIC NOT NULL CHECK (amount > 0),
+    expected_return NUMERIC NOT NULL CHECK (expected_return >= 0),
+    actual_return NUMERIC,
+    status investment_status NOT NULL DEFAULT 'active',
+    started_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    matures_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);

--- a/server/migrations/2026-05-23-190132-0000_investment_value_snapshot/down.sql
+++ b/server/migrations/2026-05-23-190132-0000_investment_value_snapshot/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS investment_value_snapshot;

--- a/server/migrations/2026-05-23-190132-0000_investment_value_snapshot/up.sql
+++ b/server/migrations/2026-05-23-190132-0000_investment_value_snapshot/up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE investment_value_snapshot (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    investment_id UUID NOT NULL REFERENCES investment(id) ON DELETE CASCADE,
+    value NUMERIC NOT NULL,
+    snapshot_date TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_investment_value_snapshot_investment_id ON investment_value_snapshot(investment_id);

--- a/server/src/infrastructure/db/models/investment.rs
+++ b/server/src/infrastructure/db/models/investment.rs
@@ -5,7 +5,6 @@ use diesel_derive_enum::DbEnum;
 use serde::Serialize;
 use uuid::Uuid;
 
-use crate::domain::investment::InvestmentStatus;
 use crate::infrastructure::db::schema;
 
 #[derive(Debug, DbEnum, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -14,26 +13,6 @@ pub enum InvestmentStatusModel {
     Active,
     Matured,
     Withdrawn,
-}
-
-impl From<InvestmentStatusModel> for InvestmentStatus {
-    fn from(value: InvestmentStatusModel) -> Self {
-        match value {
-            InvestmentStatusModel::Active => InvestmentStatus::Active,
-            InvestmentStatusModel::Matured => InvestmentStatus::Matured,
-            InvestmentStatusModel::Withdrawn => InvestmentStatus::Withdrawn,
-        }
-    }
-}
-
-impl From<InvestmentStatus> for InvestmentStatusModel {
-    fn from(value: InvestmentStatus) -> Self {
-        match value {
-            InvestmentStatus::Active => InvestmentStatusModel::Active,
-            InvestmentStatus::Matured => InvestmentStatusModel::Matured,
-            InvestmentStatus::Withdrawn => InvestmentStatusModel::Withdrawn,
-        }
-    }
 }
 
 // Strategy
@@ -79,10 +58,7 @@ pub struct NewInvestmentProposalModel {
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct InvestmentModel {
     pub id: Uuid,
-    pub group_id: Uuid,
     pub proposal_id: Uuid,
-    pub strategy_id: Uuid,
-    pub currency_id: Uuid,
     pub amount: BigDecimal,
     pub expected_return: BigDecimal,
     pub actual_return: Option<BigDecimal>,
@@ -97,10 +73,7 @@ pub struct InvestmentModel {
 #[diesel(table_name = schema::investment)]
 pub struct NewInvestmentModel {
     pub id: Uuid,
-    pub group_id: Uuid,
     pub proposal_id: Uuid,
-    pub strategy_id: Uuid,
-    pub currency_id: Uuid,
     pub amount: BigDecimal,
     pub expected_return: BigDecimal,
     pub status: InvestmentStatusModel,

--- a/server/src/infrastructure/db/models/investment.rs
+++ b/server/src/infrastructure/db/models/investment.rs
@@ -60,7 +60,7 @@ pub struct InvestmentModel {
     pub id: Uuid,
     pub proposal_id: Uuid,
     pub amount: BigDecimal,
-    pub expected_return: BigDecimal,
+    pub current_value: BigDecimal,
     pub actual_return: Option<BigDecimal>,
     pub status: InvestmentStatusModel,
     pub started_at: NaiveDateTime,
@@ -75,8 +75,20 @@ pub struct NewInvestmentModel {
     pub id: Uuid,
     pub proposal_id: Uuid,
     pub amount: BigDecimal,
-    pub expected_return: BigDecimal,
+    pub current_value: BigDecimal,
     pub status: InvestmentStatusModel,
     pub started_at: NaiveDateTime,
     pub matures_at: NaiveDateTime,
+}
+
+// Investment Value Snapshot
+
+#[derive(Queryable, Selectable, Debug, Insertable)]
+#[diesel(table_name = schema::investment_value_snapshot)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct InvestmentValueSnapshotModel {
+    pub id: Uuid,
+    pub investment_id: Uuid,
+    pub value: BigDecimal,
+    pub snapshot_date: NaiveDateTime,
 }

--- a/server/src/infrastructure/db/models/investment.rs
+++ b/server/src/infrastructure/db/models/investment.rs
@@ -1,0 +1,109 @@
+use bigdecimal::BigDecimal;
+use chrono::NaiveDateTime;
+use diesel::{Insertable, Queryable, Selectable};
+use diesel_derive_enum::DbEnum;
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::domain::investment::InvestmentStatus;
+use crate::infrastructure::db::schema;
+
+#[derive(Debug, DbEnum, Clone, Copy, PartialEq, Eq, Serialize)]
+#[db_enum(existing_type_path = "crate::infrastructure::db::schema::sql_types::InvestmentStatus")]
+pub enum InvestmentStatusModel {
+    Active,
+    Matured,
+    Withdrawn,
+}
+
+impl From<InvestmentStatusModel> for InvestmentStatus {
+    fn from(value: InvestmentStatusModel) -> Self {
+        match value {
+            InvestmentStatusModel::Active => InvestmentStatus::Active,
+            InvestmentStatusModel::Matured => InvestmentStatus::Matured,
+            InvestmentStatusModel::Withdrawn => InvestmentStatus::Withdrawn,
+        }
+    }
+}
+
+impl From<InvestmentStatus> for InvestmentStatusModel {
+    fn from(value: InvestmentStatus) -> Self {
+        match value {
+            InvestmentStatus::Active => InvestmentStatusModel::Active,
+            InvestmentStatus::Matured => InvestmentStatusModel::Matured,
+            InvestmentStatus::Withdrawn => InvestmentStatusModel::Withdrawn,
+        }
+    }
+}
+
+// Strategy
+
+#[derive(Queryable, Selectable, Debug)]
+#[diesel(table_name = schema::investment_strategy)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct InvestmentStrategyModel {
+    pub id: Uuid,
+    pub name: String,
+    pub description: String,
+    pub risk_level: String,
+    pub expected_return_percentage: BigDecimal,
+    pub duration_days: i32,
+    pub created_at: NaiveDateTime,
+}
+
+// Investment Proposal
+
+#[derive(Queryable, Selectable, Debug)]
+#[diesel(table_name = schema::investment_proposal)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct InvestmentProposalModel {
+    pub proposal_id: Uuid,
+    pub amount: BigDecimal,
+    pub strategy_id: Uuid,
+    pub currency_id: Uuid,
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = schema::investment_proposal)]
+pub struct NewInvestmentProposalModel {
+    pub proposal_id: Uuid,
+    pub amount: BigDecimal,
+    pub strategy_id: Uuid,
+    pub currency_id: Uuid,
+}
+
+// Investment
+
+#[derive(Queryable, Selectable, Debug)]
+#[diesel(table_name = schema::investment)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct InvestmentModel {
+    pub id: Uuid,
+    pub group_id: Uuid,
+    pub proposal_id: Uuid,
+    pub strategy_id: Uuid,
+    pub currency_id: Uuid,
+    pub amount: BigDecimal,
+    pub expected_return: BigDecimal,
+    pub actual_return: Option<BigDecimal>,
+    pub status: InvestmentStatusModel,
+    pub started_at: NaiveDateTime,
+    pub matures_at: NaiveDateTime,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = schema::investment)]
+pub struct NewInvestmentModel {
+    pub id: Uuid,
+    pub group_id: Uuid,
+    pub proposal_id: Uuid,
+    pub strategy_id: Uuid,
+    pub currency_id: Uuid,
+    pub amount: BigDecimal,
+    pub expected_return: BigDecimal,
+    pub status: InvestmentStatusModel,
+    pub started_at: NaiveDateTime,
+    pub matures_at: NaiveDateTime,
+}

--- a/server/src/infrastructure/db/models/investment.rs
+++ b/server/src/infrastructure/db/models/investment.rs
@@ -83,11 +83,20 @@ pub struct NewInvestmentModel {
 
 // Investment Value Snapshot
 
-#[derive(Queryable, Selectable, Debug, Insertable)]
+#[derive(Queryable, Selectable, Debug)]
 #[diesel(table_name = schema::investment_value_snapshot)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct InvestmentValueSnapshotModel {
     pub id: Uuid,
+    pub investment_id: Uuid,
+    pub value: BigDecimal,
+    pub snapshot_date: NaiveDateTime,
+    pub created_at: NaiveDateTime,
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = schema::investment_value_snapshot)]
+pub struct NewInvestmentValueSnapshotModel {
     pub investment_id: Uuid,
     pub value: BigDecimal,
     pub snapshot_date: NaiveDateTime,

--- a/server/src/infrastructure/db/models/mod.rs
+++ b/server/src/infrastructure/db/models/mod.rs
@@ -3,3 +3,5 @@ pub mod governance;
 pub mod group;
 pub mod treasury;
 pub mod user;
+
+pub mod investment;

--- a/server/src/infrastructure/db/schema.rs
+++ b/server/src/infrastructure/db/schema.rs
@@ -18,6 +18,10 @@ pub mod sql_types {
     pub struct GroupStatus;
 
     #[derive(diesel::query_builder::QueryId, Clone, diesel::sql_types::SqlType)]
+    #[diesel(postgres_type(name = "investment_status"))]
+    pub struct InvestmentStatus;
+
+    #[derive(diesel::query_builder::QueryId, Clone, diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "proposal_status"))]
     pub struct ProposalStatus;
 
@@ -107,6 +111,45 @@ diesel::table! {
         balance -> Numeric,
         created_at -> Timestamp,
         updated_at -> Timestamp,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use super::sql_types::InvestmentStatus;
+
+    investment (id) {
+        id -> Uuid,
+        proposal_id -> Uuid,
+        amount -> Numeric,
+        expected_return -> Numeric,
+        actual_return -> Nullable<Numeric>,
+        status -> InvestmentStatus,
+        started_at -> Timestamp,
+        matures_at -> Timestamp,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+diesel::table! {
+    investment_proposal (proposal_id) {
+        proposal_id -> Uuid,
+        amount -> Numeric,
+        strategy_id -> Uuid,
+        currency_id -> Uuid,
+    }
+}
+
+diesel::table! {
+    investment_strategy (id) {
+        id -> Uuid,
+        name -> Text,
+        description -> Text,
+        risk_level -> Text,
+        expected_return_percentage -> Numeric,
+        duration_days -> Int4,
+        created_at -> Timestamp,
     }
 }
 
@@ -228,6 +271,10 @@ diesel::joinable!(fund_round_proposal -> currency (currency_id));
 diesel::joinable!(fund_round_proposal -> proposal (proposal_id));
 diesel::joinable!(group_wallet -> currency (currency_id));
 diesel::joinable!(group_wallet -> group (group_id));
+diesel::joinable!(investment -> proposal (proposal_id));
+diesel::joinable!(investment_proposal -> currency (currency_id));
+diesel::joinable!(investment_proposal -> investment_strategy (strategy_id));
+diesel::joinable!(investment_proposal -> proposal (proposal_id));
 diesel::joinable!(new_member_proposal -> proposal (proposal_id));
 diesel::joinable!(new_member_proposal -> user (new_member_id));
 diesel::joinable!(proposal -> group (group_id));
@@ -254,6 +301,9 @@ diesel::allow_tables_to_appear_in_same_query!(
     fund_round_proposal,
     group,
     group_wallet,
+    investment,
+    investment_proposal,
+    investment_strategy,
     new_member_proposal,
     proposal,
     transaction,

--- a/server/src/infrastructure/db/schema.rs
+++ b/server/src/infrastructure/db/schema.rs
@@ -122,7 +122,7 @@ diesel::table! {
         id -> Uuid,
         proposal_id -> Uuid,
         amount -> Numeric,
-        expected_return -> Numeric,
+        current_value -> Numeric,
         actual_return -> Nullable<Numeric>,
         status -> InvestmentStatus,
         started_at -> Timestamp,
@@ -149,6 +149,16 @@ diesel::table! {
         risk_level -> Text,
         expected_return_percentage -> Numeric,
         duration_days -> Int4,
+        created_at -> Timestamp,
+    }
+}
+
+diesel::table! {
+    investment_value_snapshot (id) {
+        id -> Uuid,
+        investment_id -> Uuid,
+        value -> Numeric,
+        snapshot_date -> Timestamp,
         created_at -> Timestamp,
     }
 }
@@ -275,6 +285,7 @@ diesel::joinable!(investment -> investment_proposal (proposal_id));
 diesel::joinable!(investment_proposal -> currency (currency_id));
 diesel::joinable!(investment_proposal -> investment_strategy (strategy_id));
 diesel::joinable!(investment_proposal -> proposal (proposal_id));
+diesel::joinable!(investment_value_snapshot -> investment (investment_id));
 diesel::joinable!(new_member_proposal -> proposal (proposal_id));
 diesel::joinable!(new_member_proposal -> user (new_member_id));
 diesel::joinable!(proposal -> group (group_id));
@@ -304,6 +315,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     investment,
     investment_proposal,
     investment_strategy,
+    investment_value_snapshot,
     new_member_proposal,
     proposal,
     transaction,

--- a/server/src/infrastructure/db/schema.rs
+++ b/server/src/infrastructure/db/schema.rs
@@ -271,7 +271,7 @@ diesel::joinable!(fund_round_proposal -> currency (currency_id));
 diesel::joinable!(fund_round_proposal -> proposal (proposal_id));
 diesel::joinable!(group_wallet -> currency (currency_id));
 diesel::joinable!(group_wallet -> group (group_id));
-diesel::joinable!(investment -> proposal (proposal_id));
+diesel::joinable!(investment -> investment_proposal (proposal_id));
 diesel::joinable!(investment_proposal -> currency (currency_id));
 diesel::joinable!(investment_proposal -> investment_strategy (strategy_id));
 diesel::joinable!(investment_proposal -> proposal (proposal_id));


### PR DESCRIPTION
This pull request introduces new database tables and Rust models to support investment strategies, proposals, and investments in the system. It includes SQL migrations for creating and dropping the relevant tables and types, as well as Rust model definitions to interact with these tables using Diesel ORM.

**Database schema additions:**

* Added `investment_strategy` table to store different investment strategies, including fields for risk level, expected return, and duration. Also includes initial seed data for three strategies.
* Added `investment_proposal` table to represent proposals linked to strategies, currencies, and amounts, with appropriate foreign key constraints.
* Added `investment` table to track actual investments, including group, proposal, strategy, currency, amounts, returns, status, and timestamps. Introduced a new enum type `investment_status` for tracking investment state.

**Rust model implementations:**

* Implemented Rust models in `investment.rs` for `InvestmentStrategy`, `InvestmentProposal`, and `Investment`, along with insertable structs and enum mapping for investment status, ensuring type safety and Diesel ORM integration.

**Migration rollbacks:**

* Added down migrations to drop the created tables and enum type for clean rollback capability. [[1]](diffhunk://#diff-c20650db1dc7a315b4aa045c57b528041b00f57cf6df90359ea2462fe63e96c1R1) [[2]](diffhunk://#diff-4c8eebed864891f4e740dd0284d1011357ed533c525064907986871f824b85dbR1) [[3]](diffhunk://#diff-a87e5123c4b76daa14d0d885d7b015d9c9301dc6fac09eccc477d759a99421c6R1-R2)